### PR TITLE
Update and enable Mellanox OFED

### DIFF
--- a/.kres.yaml
+++ b/.kres.yaml
@@ -40,6 +40,7 @@ spec:
     - kernel
     - drbd-pkg
     - gasket-driver-pkg
+    - mellanox-ofed-pkg
     - nvidia-open-gpu-kernel-modules-lts-pkg
     - nvidia-open-gpu-kernel-modules-production-pkg
     - zfs-pkg

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED, PLEASE DO NOT EDIT.
 #
-# Generated on 2024-08-07T16:43:47Z by kres dbf015a.
+# Generated on 2024-09-01T10:15:16Z by kres b5ca957.
 
 # common variables
 
@@ -79,6 +79,7 @@ TARGETS += xfsprogs
 TARGETS += kernel
 TARGETS += drbd-pkg
 TARGETS += gasket-driver-pkg
+TARGETS += mellanox-ofed-pkg
 TARGETS += nvidia-open-gpu-kernel-modules-lts-pkg
 TARGETS += nvidia-open-gpu-kernel-modules-production-pkg
 TARGETS += zfs-pkg

--- a/Pkgfile
+++ b/Pkgfile
@@ -123,9 +123,9 @@ vars:
   lvm2_sha256: 4c5a6923bd1ace7ce04474608a84937ce053ba91b1ace9f0b0017268e732dc7c
   lvm2_sha512: 17cd24ceee8026481566824b688dafd03ec816201d5cb3549cb7fc8a36f4cdaa982faaef4dcd26debfe775dea5ffa2744798164314ea6dc99a84f8ccccfc33ff
 
-  mellanox_ofed_version: 5.9-0.5.6.0
-  mellanox_ofed_sha256: 4503258cbe92b00c734e612c3a7ad1d71e023fdffae2a2c119f7b537505e499c
-  mellanox_ofed_sha512: 58604ea89aa8351727532c48f0c59b4e533ba8bfcef9533f45d94e15ffdcf3a5c464398706cad14ebf3826b132972bd044fadbf7f047e60bdb0c2a454c96acd7
+  mellanox_ofed_version: 24.07-0.6.1.0
+  mellanox_ofed_sha256: 2d34880b9b79291cb555409c471f06c7eb4375d2f46c96384bf1f71bfaa69dcc
+  mellanox_ofed_sha512: d2cc757ec8de3fe282c5e51abda6d072810c49d2aae515b4e1039d8ebc11af468266a6eee949ded27fec1e75961b0bce5fca601e0ecaf96e0aa127915701b0e8
 
   # renovate: datasource=git-tags extractVersion=^v(?<version>.*)$ depName=git://git.musl-libc.org/musl
   musl_version: 1.2.5

--- a/mellanox-ofed/pkg.yaml
+++ b/mellanox-ofed/pkg.yaml
@@ -16,10 +16,10 @@ steps:
         tar -xzf mellanox_ofed.tgz --strip-components=1
 
         cd SOURCES
-        tar xf mlnx-ofed-kernel_5.9.orig.tar.gz
+        tar xf mlnx-ofed-kernel_24.07.OFED.24.07.0.6.1.1.orig.tar.gz
     build:
       - |
-        cd SOURCES/mlnx-ofed-kernel-5.9
+        cd SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1
 
         ./configure --with-core-mod \
           --with-user_mad-mod \
@@ -35,7 +35,7 @@ steps:
         make kernel -j $(nproc)
     install:
       - |
-        cd SOURCES/mlnx-ofed-kernel-5.9
+        cd SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1
 
         mkdir -p /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/
         cp /src/modules.order /rootfs/lib/modules/$(cat /src/include/config/kernel.release)/

--- a/mellanox-ofed/pkg.yaml
+++ b/mellanox-ofed/pkg.yaml
@@ -15,6 +15,10 @@ steps:
       - |
         tar -xzf mellanox_ofed.tgz --strip-components=1
 
+        ln -sv /toolchain/bin/rm /bin/rm
+        ln -sv /toolchain/bin/cp /bin/cp
+        ln -sv /toolchain/bin/mktemp /bin/mktemp
+
         cd SOURCES
         tar xf mlnx-ofed-kernel_24.07.OFED.24.07.0.6.1.1.orig.tar.gz
     build:

--- a/mellanox-ofed/pkg.yaml
+++ b/mellanox-ofed/pkg.yaml
@@ -15,9 +15,12 @@ steps:
       - |
         tar -xzf mellanox_ofed.tgz --strip-components=1
 
-        ln -sv /toolchain/bin/rm /bin/rm
+        ln -sv /toolchain/bin/cat /bin/cat
         ln -sv /toolchain/bin/cp /bin/cp
+        ln -sv /toolchain/bin/grep /bin/grep
+        ln -sv /toolchain/bin/mkdir /bin/mkdir
         ln -sv /toolchain/bin/mktemp /bin/mktemp
+        ln -sv /toolchain/bin/rm /bin/rm
 
         cd SOURCES
         tar xf mlnx-ofed-kernel_24.07.OFED.24.07.0.6.1.1.orig.tar.gz
@@ -36,7 +39,7 @@ steps:
           --kernel-sources=/src \
           -j $(nproc)
 
-        make kernel -j $(nproc)
+        make AM_DEFAULT_VERBOSITY=1 V=1 kernel -j $(nproc)
     install:
       - |
         cd SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1


### PR DESCRIPTION
Not currently working due to following errors:
```
make[1]: Entering directory '/home/jpg/src/talos/pkgs'
make[2]: Entering directory '/home/jpg/src/talos/pkgs'
[+] Building 51.3s (49/52)                                                                                                                                  docker-container:local1
 => [internal] load build definition from Pkgfile                                                                                                                              0.0s
 => => transferring dockerfile: 13.03kB                                                                                                                                        0.0s
 => resolve image config for docker-image://ghcr.io/siderolabs/bldr:v0.3.2                                                                                                     1.1s
 => CACHED docker-image://ghcr.io/siderolabs/bldr:v0.3.2@sha256:09de89a613e38321ce471caada5052cc63a71169e968239a1f6ff0bc7c262b55                                               0.0s
 => => resolve ghcr.io/siderolabs/bldr:v0.3.2@sha256:09de89a613e38321ce471caada5052cc63a71169e968239a1f6ff0bc7c262b55                                                          0.0s
 => load Pkgfile, pkg.yamls and vars.yamls                                                                                                                                     0.1s
 => => transferring dockerfile: 24.33MB                                                                                                                                        0.1s
 => mellanox-ofed-pkg:download https://www.mellanox.com/downloads/ofed/MLNX_OFED-24.07-0.6.1.0/MLNX_OFED_SRC-debian-24.07-0.6.1.0.tgz -> mellanox_ofed.tgz                     0.0s
 => context                                                                                                                                                                    0.0s
 => => transferring context: 477.42kB                                                                                                                                          0.0s
 => cksum                                                                                                                                                                      2.0s
 => => resolve docker.io/library/alpine:3.20                                                                                                                                   2.0s
 => mkdir /pkg                                                                                                                                                                 0.0s
 => kernel-prepare:download https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-6.6.47.tar.xz -> linux.tar.xz                                                                   0.0s
 => docker-image://ghcr.io/siderolabs/tools:v1.8.0                                                                                                                             0.9s
 => => resolve ghcr.io/siderolabs/tools:v1.8.0                                                                                                                                 0.9s
 => CACHED kernel-prepare:copy                                                                                                                                                 0.0s
 => CACHED kernel-prepare:context /kernel/prepare -> /pkg                                                                                                                      0.0s
 => CACHED kernel-prepare:mkdir /tmp/build/0                                                                                                                                   0.0s
 => CACHED cksum-apkinstall                                                                                                                                                    0.0s
 => CACHED kernel-prepare:cksum-prepare                                                                                                                                        0.0s
 => CACHED kernel-prepare:cksum-verify                                                                                                                                         0.0s
 => CACHED kernel-prepare:download finalize                                                                                                                                    0.0s
 => CACHED kernel-prepare:download                                                                                                                                             0.0s
 => CACHED kernel-prepare:prepare-0                                                                                                                                            0.0s
 => CACHED kernel-prepare:prepare-0                                                                                                                                            0.0s
 => CACHED kernel-prepare:install-0                                                                                                                                            0.0s
 => CACHED kernel-prepare:finalize /src -> /src                                                                                                                                0.0s
 => CACHED kernel-prepare:finalize /toolchain -> /toolchain                                                                                                                    0.0s
 => CACHED kernel-prepare:finalize /usr -> /usr                                                                                                                                0.0s
 => CACHED kernel-prepare:finalize /bin -> /bin                                                                                                                                0.0s
 => CACHED kernel-prepare:finalize /lib -> /lib                                                                                                                                0.0s
 => CACHED kernel-prepare:finalize                                                                                                                                             0.0s
 => CACHED kernel-build:copy                                                                                                                                                   0.0s
 => CACHED kernel-build:context /kernel/build -> /pkg                                                                                                                          0.0s
 => CACHED kernel-build:mkdir /tmp/build/0                                                                                                                                     0.0s
 => CACHED kernel-build:prepare-0                                                                                                                                              0.0s
 => CACHED kernel-build:prepare-0                                                                                                                                              0.0s
 => CACHED kernel-build:build-0                                                                                                                                                0.0s
 => CACHED kernel-build:build-0                                                                                                                                                0.0s
 => CACHED kernel-build:finalize /src -> /src                                                                                                                                  0.0s
 => CACHED kernel-build:finalize /toolchain -> /toolchain                                                                                                                      0.0s
 => CACHED kernel-build:finalize /usr -> /usr                                                                                                                                  0.0s
 => CACHED kernel-build:finalize /bin -> /bin                                                                                                                                  0.0s
 => CACHED kernel-build:finalize /lib -> /lib                                                                                                                                  0.0s
 => CACHED kernel-build:finalize                                                                                                                                               0.0s
 => CACHED mellanox-ofed-pkg:copy                                                                                                                                              0.0s
 => CACHED mellanox-ofed-pkg:context /mellanox-ofed -> /pkg                                                                                                                    0.0s
 => CACHED mellanox-ofed-pkg:mkdir /tmp/build/0                                                                                                                                0.0s
 => CACHED mellanox-ofed-pkg:cksum-prepare                                                                                                                                     0.0s
 => CACHED mellanox-ofed-pkg:cksum-verify                                                                                                                                      0.0s
 => CACHED mellanox-ofed-pkg:download finalize                                                                                                                                 0.0s
 => CACHED mellanox-ofed-pkg:download                                                                                                                                          0.0s
 => mellanox-ofed-pkg:prepare-0                                                                                                                                                0.4s
 => ERROR mellanox-ofed-pkg:build-0                                                                                                                                           47.7s
------
 > mellanox-ofed-pkg:build-0:
0.216 Warning: CONFIG_MLX5_TC_CT not supported in kernel once CONFIG_NF_FLOW_TABLE not set.
0.224 Warning: CONFIG_TLS_DEVICE is not enabled in the kernel, cannot enable CONFIG_MLX5_EN_TLS.
0.233 backports_applied does not exist. running ofed_patch.sh
0.233 /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/ofed_scripts/ofed_patch.sh
0.236 mkdir -p /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/patches
0.237 touch /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/patches/quiltrc
0.238 /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/kernel_patches/fixes directory does not exist
0.238 getting backport dir for kernel version 6.10.7-arch1-1
0.238 found backport dir backports
0.238
0.238 Applying patches for backports kernel:
0.238 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0001-BACKPORT-drivers-base-auxiliary.c.patch
0.239 patching file drivers/base/auxiliary.c
0.239 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0002-BACKPORT-drivers-infiniband-core-addr.c.patch
0.240 patching file drivers/infiniband/core/addr.c
0.240 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0003-BACKPORT-drivers-infiniband-core-cache.c.patch
0.241 patching file drivers/infiniband/core/cache.c
0.241 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0004-BACKPORT-drivers-infiniband-core-cgroup.c.patch
0.242 patching file drivers/infiniband/core/cgroup.c
0.242 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0005-BACKPORT-drivers-infiniband-core-cm_trace.c.patch
0.242 patching file drivers/infiniband/core/cm_trace.c
0.243 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0006-BACKPORT-drivers-infiniband-core-cm_trace.h.patch
0.243 patching file drivers/infiniband/core/cm_trace.h
0.243 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0007-BACKPORT-drivers-infiniband-core-cma.c.patch
0.244 patching file drivers/infiniband/core/cma.c
0.245 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0008-BACKPORT-drivers-infiniband-core-cma_configfs.c.patch
0.245 patching file drivers/infiniband/core/cma_configfs.c
0.246 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0009-BACKPORT-drivers-infiniband-core-cma_trace.h.patch
0.246 patching file drivers/infiniband/core/cma_trace.h
0.246 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0010-BACKPORT-drivers-infiniband-core-core_priv.h.patch
0.247 patching file drivers/infiniband/core/core_priv.h
0.247 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0011-BACKPORT-drivers-infiniband-core-counters.c.patch
0.248 patching file drivers/infiniband/core/counters.c
0.248 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0012-BACKPORT-drivers-infiniband-core-cq.c.patch
0.248 patching file drivers/infiniband/core/cq.c
0.249 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0013-BACKPORT-drivers-infiniband-core-device.c.patch
0.249 patching file drivers/infiniband/core/device.c
0.250 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0014-BACKPORT-drivers-infiniband-core-iwpm_util.c.patch
0.250 patching file drivers/infiniband/core/iwpm_util.c
0.250 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0015-BACKPORT-drivers-infiniband-core-lag.c.patch
0.251 patching file drivers/infiniband/core/lag.c
0.251 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0016-BACKPORT-drivers-infiniband-core-mad.c.patch
0.252 patching file drivers/infiniband/core/mad.c
0.252 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0017-BACKPORT-drivers-infiniband-core-netlink.c.patch
0.253 patching file drivers/infiniband/core/netlink.c
0.253 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0018-BACKPORT-drivers-infiniband-core-nldev.c.patch
0.254 patching file drivers/infiniband/core/nldev.c
0.254 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0019-BACKPORT-drivers-infiniband-core-peer_mem.c.patch
0.255 patching file drivers/infiniband/core/peer_mem.c
0.255 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0020-BACKPORT-drivers-infiniband-core-rdma_core.c.patch
0.256 patching file drivers/infiniband/core/rdma_core.c
0.256 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0021-BACKPORT-drivers-infiniband-core-roce_gid_mgmt.c.patch
0.256 patching file drivers/infiniband/core/roce_gid_mgmt.c
0.257 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0022-BACKPORT-drivers-infiniband-core-rw.c.patch
0.257 patching file drivers/infiniband/core/rw.c
0.258 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0023-BACKPORT-drivers-infiniband-core-sa_query.c.patch
0.258 patching file drivers/infiniband/core/sa_query.c
0.259 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0024-BACKPORT-drivers-infiniband-core-sysfs.c.patch
0.259 patching file drivers/infiniband/core/sysfs.c
0.260 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0025-BACKPORT-drivers-infiniband-core-trace.c.patch
0.260 patching file drivers/infiniband/core/trace.c
0.260 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0026-BACKPORT-drivers-infiniband-core-ud_header.c.patch
0.261 patching file drivers/infiniband/core/ud_header.c
0.261 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0027-BACKPORT-drivers-infiniband-core-umem.c.patch
0.262 patching file drivers/infiniband/core/umem.c
0.262 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0028-BACKPORT-drivers-infiniband-core-umem_dmabuf.c.patch
0.263 patching file drivers/infiniband/core/umem_dmabuf.c
0.263 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0029-BACKPORT-drivers-infiniband-core-umem_odp.c.patch
0.263 patching file drivers/infiniband/core/umem_odp.c
0.264 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0030-BACKPORT-drivers-infiniband-core-user_mad.c.patch
0.264 patching file drivers/infiniband/core/user_mad.c
0.265 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0031-BACKPORT-drivers-infiniband-core-uverbs.h.patch
0.265 patching file drivers/infiniband/core/uverbs.h
0.265 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0032-BACKPORT-drivers-infiniband-core-uverbs_cmd.c.patch
0.266 patching file drivers/infiniband/core/uverbs_cmd.c
0.266 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0033-BACKPORT-drivers-infiniband-core-uverbs_ioctl.c.patch
0.267 patching file drivers/infiniband/core/uverbs_ioctl.c
0.267 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0034-BACKPORT-drivers-infiniband-core-uverbs_main.c.patch
0.268 patching file drivers/infiniband/core/uverbs_main.c
0.268 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0035-BACKPORT-drivers-infiniband-core-uverbs_uapi.c.patch
0.269 patching file drivers/infiniband/core/uverbs_uapi.c
0.269 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0036-BACKPORT-drivers-infiniband-core-verbs.c.patch
0.269 patching file drivers/infiniband/core/verbs.c
0.270 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0037-BACKPORT-drivers-infiniband-debug-memtrack.c.patch
0.270 patching file drivers/infiniband/debug/memtrack.c
0.271 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0038-BACKPORT-drivers-infiniband-hw-mlx5-Makefile.patch
0.271 patching file drivers/infiniband/hw/mlx5/Makefile
0.271 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0039-BACKPORT-drivers-infiniband-hw-mlx5-cq.c.patch
0.272 patching file drivers/infiniband/hw/mlx5/cq.c
0.272 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0040-BACKPORT-drivers-infiniband-hw-mlx5-doorbell.c.patch
0.273 patching file drivers/infiniband/hw/mlx5/doorbell.c
0.273 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0041-BACKPORT-drivers-infiniband-hw-mlx5-fs.c.patch
0.274 patching file drivers/infiniband/hw/mlx5/fs.c
0.274 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0042-BACKPORT-drivers-infiniband-hw-mlx5-ib_virt.c.patch
0.275 patching file drivers/infiniband/hw/mlx5/ib_virt.c
0.275 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0043-BACKPORT-drivers-infiniband-hw-mlx5-main.c.patch
0.275 patching file drivers/infiniband/hw/mlx5/main.c
0.276 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0044-BACKPORT-drivers-infiniband-hw-mlx5-main_ext.c.patch
0.277 patching file drivers/infiniband/hw/mlx5/main_ext.c
0.277 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0046-BACKPORT-drivers-infiniband-hw-mlx5-mlx5_ib.h.patch
0.277 patching file drivers/infiniband/hw/mlx5/mlx5_ib.h
0.278 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0047-BACKPORT-drivers-infiniband-hw-mlx5-odp.c.patch
0.278 patching file drivers/infiniband/hw/mlx5/odp.c
0.279 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0048-BACKPORT-drivers-infiniband-hw-mlx5-qp.c.patch
0.279 patching file drivers/infiniband/hw/mlx5/qp.c
0.280 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0049-BACKPORT-drivers-infiniband-hw-mlx5-srq.c.patch
0.281 patching file drivers/infiniband/hw/mlx5/srq.c
0.281 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0050-BACKPORT-drivers-infiniband-hw-mlx5-srq_cmd.c.patch
0.281 patching file drivers/infiniband/hw/mlx5/srq_cmd.c
0.282 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0051-BACKPORT-drivers-infiniband-hw-mlx5-umr.c.patch
0.282 patching file drivers/infiniband/hw/mlx5/umr.c
0.282 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0052-BACKPORT-drivers-infiniband-hw-mlx5-wr.c.patch
0.283 patching file drivers/infiniband/hw/mlx5/wr.c
0.283 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0053-BACKPORT-drivers-infiniband-ulp-ipoib-ipoib.h.patch
0.284 patching file drivers/infiniband/ulp/ipoib/ipoib.h
0.284 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0054-BACKPORT-drivers-infiniband-ulp-ipoib-ipoib_cm.c.patch
0.285 patching file drivers/infiniband/ulp/ipoib/ipoib_cm.c
0.285 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0055-BACKPORT-drivers-infiniband-ulp-ipoib-ipoib_ethtool..patch
0.286 patching file drivers/infiniband/ulp/ipoib/ipoib_ethtool.c
0.286 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0056-BACKPORT-drivers-infiniband-ulp-ipoib-ipoib_fs.c.patch
0.286 patching file drivers/infiniband/ulp/ipoib/ipoib_fs.c
0.287 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0057-BACKPORT-drivers-infiniband-ulp-ipoib-ipoib_multicas.patch
0.287 patching file drivers/infiniband/ulp/ipoib/ipoib_multicast.c
0.287 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0058-BACKPORT-drivers-infiniband-ulp-ipoib-ipoib_netlink..patch
0.288 patching file drivers/infiniband/ulp/ipoib/ipoib_netlink.c
0.288 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0059-BACKPORT-drivers-infiniband-ulp-ipoib-ipoib_vlan.c.patch
0.289 patching file drivers/infiniband/ulp/ipoib/ipoib_vlan.c
0.289 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0060-BACKPORT-drivers-infiniband-ulp-iser-iscsi_iser.c.patch
0.289 patching file drivers/infiniband/ulp/iser/iscsi_iser.c
0.290 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0061-BACKPORT-drivers-infiniband-ulp-iser-iscsi_iser.h.patch
0.291 patching file drivers/infiniband/ulp/iser/iscsi_iser.h
0.291 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0062-BACKPORT-drivers-infiniband-ulp-iser-iser_memory.c.patch
0.291 patching file drivers/infiniband/ulp/iser/iser_memory.c
0.292 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0063-BACKPORT-drivers-infiniband-ulp-iser-iser_verbs.c.patch
0.292 patching file drivers/infiniband/ulp/iser/iser_verbs.c
0.292 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0064-BACKPORT-drivers-infiniband-ulp-isert-ib_isert.c.patch
0.293 patching file drivers/infiniband/ulp/isert/ib_isert.c
0.294 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0065-BACKPORT-drivers-infiniband-ulp-isert-ib_isert.h.patch
0.294 patching file drivers/infiniband/ulp/isert/ib_isert.h
0.294 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0066-BACKPORT-drivers-infiniband-ulp-srp-ib_srp.c.patch
0.295 patching file drivers/infiniband/ulp/srp/ib_srp.c
0.296 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0067-BACKPORT-drivers-infiniband-ulp-srp-ib_srp.h.patch
0.296 patching file drivers/infiniband/ulp/srp/ib_srp.h
0.296 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0068-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-Mak.patch
0.297 patching file drivers/net/ethernet/mellanox/mlx5/core/Makefile
0.297 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0069-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-all.patch
0.298 patching file drivers/net/ethernet/mellanox/mlx5/core/alloc.c
0.298 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0070-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-cmd.patch
0.299 patching file drivers/net/ethernet/mellanox/mlx5/core/cmd.c
0.299 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0071-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-cq..patch
0.300 patching file drivers/net/ethernet/mellanox/mlx5/core/cq.c
0.300 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0072-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-crd.patch
0.301 patching file drivers/net/ethernet/mellanox/mlx5/core/crdump.c
0.301 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0073-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-dev.patch
0.301 patching file drivers/net/ethernet/mellanox/mlx5/core/devlink.h
0.302 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0074-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-dia.patch
0.302 patching file drivers/net/ethernet/mellanox/mlx5/core/diag/en_tc_tracepoint.c
0.302 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0075-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-dia.patch
0.303 patching file drivers/net/ethernet/mellanox/mlx5/core/diag/en_tc_tracepoint.h
0.303 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0076-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-dia.patch
0.304 patching file drivers/net/ethernet/mellanox/mlx5/core/diag/fs_tracepoint.c
0.304 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0077-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-dia.patch
0.305 patching file drivers/net/ethernet/mellanox/mlx5/core/diag/fs_tracepoint.h
0.305 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0078-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-dia.patch
0.305 patching file drivers/net/ethernet/mellanox/mlx5/core/diag/fw_tracer.h
0.306 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0079-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-ecp.patch
0.306 patching file drivers/net/ethernet/mellanox/mlx5/core/ecpf.c
0.307 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0080-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.307 patching file drivers/net/ethernet/mellanox/mlx5/core/en/devlink.h
0.307 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0081-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.308 patching file drivers/net/ethernet/mellanox/mlx5/core/en/fs.h
0.308 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0082-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.309 patching file drivers/net/ethernet/mellanox/mlx5/core/en/htb.c
0.309 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0083-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.310 patching file drivers/net/ethernet/mellanox/mlx5/core/en/htb.h
0.310 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0084-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.311 patching file drivers/net/ethernet/mellanox/mlx5/core/en/params.c
0.311 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0085-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.312 patching file drivers/net/ethernet/mellanox/mlx5/core/en/params.h
0.312 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0086-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.312 patching file drivers/net/ethernet/mellanox/mlx5/core/en/port_buffer.c
0.313 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0087-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.313 patching file drivers/net/ethernet/mellanox/mlx5/core/en/port_buffer.h
0.314 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0088-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.314 patching file drivers/net/ethernet/mellanox/mlx5/core/en/ptp.c
0.315 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0089-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.315 patching file drivers/net/ethernet/mellanox/mlx5/core/en/ptp.h
0.315 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0090-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.316 patching file drivers/net/ethernet/mellanox/mlx5/core/en/qos.c
0.316 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0091-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.317 patching file drivers/net/ethernet/mellanox/mlx5/core/en/rep/bond.c
0.317 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0092-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.318 patching file drivers/net/ethernet/mellanox/mlx5/core/en/rep/bridge.c
0.318 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0093-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.319 patching file drivers/net/ethernet/mellanox/mlx5/core/en/rep/meter.c
0.319 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0094-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.320 patching file drivers/net/ethernet/mellanox/mlx5/core/en/rep/neigh.c
0.320 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0095-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.320 patching file drivers/net/ethernet/mellanox/mlx5/core/en/rep/sysfs.c
0.321 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0096-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.321 patching file drivers/net/ethernet/mellanox/mlx5/core/en/rep/tc.h
0.321 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0097-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.322 patching file drivers/net/ethernet/mellanox/mlx5/core/en/selq.c
0.322 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0098-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.323 patching file drivers/net/ethernet/mellanox/mlx5/core/en/selq.h
0.323 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0099-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.324 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc/act/ct.c
0.324 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0100-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.325 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc/act/mirred.c
0.325 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0101-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.325 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc/act/mpls.c
0.326 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0102-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.326 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc/act/police.c
0.326 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0103-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.327 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc/act/prio.c
0.327 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0104-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.328 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc/act/ptype.c
0.328 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0105-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.329 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc/act/vlan.c
0.329 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0106-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.329 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc/act_stats.c
0.330 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0107-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.330 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc/act_stats.h
0.331 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0108-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.331 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc/ct_fs_smfs.c
0.331 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0109-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.332 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc/int_port.c
0.332 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0110-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.333 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc/meter.c
0.333 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0111-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.334 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc/post_meter.c
0.334 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0112-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.335 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc/post_meter.h
0.335 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0113-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.336 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc/sample.c
0.336 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0114-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.336 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc/sample.h
0.337 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0115-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.337 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc_ct.c
0.338 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0116-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.338 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc_ct.h
0.338 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0117-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.339 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc_priv.h
0.339 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0118-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.340 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc_tun.c
0.340 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0119-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.341 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc_tun.h
0.341 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0120-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.341 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc_tun_encap.c
0.342 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0121-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.342 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc_tun_geneve.c
0.343 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0122-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.343 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc_tun_mplsoudp.c
0.343 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0123-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.344 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc_tun_vxlan.c
0.344 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0124-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.345 patching file drivers/net/ethernet/mellanox/mlx5/core/en/trap.c
0.345 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0125-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.345 patching file drivers/net/ethernet/mellanox/mlx5/core/en/trap.h
0.346 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0126-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.346 patching file drivers/net/ethernet/mellanox/mlx5/core/en/txrx.h
0.347 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0127-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.347 patching file drivers/net/ethernet/mellanox/mlx5/core/en/xsk/pool.h
0.347 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0128-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.348 patching file drivers/net/ethernet/mellanox/mlx5/core/en/xsk/rx.h
0.348 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0129-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.349 patching file drivers/net/ethernet/mellanox/mlx5/core/en/xsk/setup.h
0.349 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0130-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.349 patching file drivers/net/ethernet/mellanox/mlx5/core/en/xsk/tx.h
0.350 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0131-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.350 patching file drivers/net/ethernet/mellanox/mlx5/core/en_accel/en_accel.h
0.350 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0132-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.351 patching file drivers/net/ethernet/mellanox/mlx5/core/en_accel/ipsec.h
0.351 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0133-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.352 patching file drivers/net/ethernet/mellanox/mlx5/core/en_accel/ipsec_fs.c
0.352 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0134-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.353 patching file drivers/net/ethernet/mellanox/mlx5/core/en_accel/ipsec_rxtx.c
0.353 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0135-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.354 patching file drivers/net/ethernet/mellanox/mlx5/core/en_accel/ipsec_rxtx.h
0.354 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0136-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.355 patching file drivers/net/ethernet/mellanox/mlx5/core/en_accel/ktls.c
0.355 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0137-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.356 patching file drivers/net/ethernet/mellanox/mlx5/core/en_accel/ktls_tx.c
0.356 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0138-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.357 patching file drivers/net/ethernet/mellanox/mlx5/core/en_accel/ktls_txrx.c
0.357 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0139-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.357 patching file drivers/net/ethernet/mellanox/mlx5/core/en_accel/ktls_txrx.h
0.358 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0140-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.358 patching file drivers/net/ethernet/mellanox/mlx5/core/en_accel/ktls_utils.h
0.358 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0141-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.359 patching file drivers/net/ethernet/mellanox/mlx5/core/en_accel/macsec.c
0.359 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0142-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.360 patching file drivers/net/ethernet/mellanox/mlx5/core/en_debugfs.c
0.360 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0143-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.361 patching file drivers/net/ethernet/mellanox/mlx5/core/en_fs.c
0.361 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0144-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.362 patching file drivers/net/ethernet/mellanox/mlx5/core/en_fs_ethtool.c
0.362 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0145-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.363 patching file drivers/net/ethernet/mellanox/mlx5/core/en_rep.h
0.363 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0146-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.364 patching file drivers/net/ethernet/mellanox/mlx5/core/en_selftest.c
0.364 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0147-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.364 patching file drivers/net/ethernet/mellanox/mlx5/core/en_stats.c
0.365 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0148-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.366 patching file drivers/net/ethernet/mellanox/mlx5/core/en_stats.h
0.366 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0149-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.367 patching file drivers/net/ethernet/mellanox/mlx5/core/en_sysfs.c
0.371 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0150-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.371 patching file drivers/net/ethernet/mellanox/mlx5/core/en_tc.h
0.371 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0151-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.372 patching file drivers/net/ethernet/mellanox/mlx5/core/en_tx.c
0.373 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0152-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.373 patching file drivers/net/ethernet/mellanox/mlx5/core/en_txrx.c
0.373 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0153-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-eq..patch
0.374 patching file drivers/net/ethernet/mellanox/mlx5/core/eq.c
0.375 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0154-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-esw.patch
0.375 patching file drivers/net/ethernet/mellanox/mlx5/core/esw/bridge.c
0.376 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0155-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-esw.patch
0.376 patching file drivers/net/ethernet/mellanox/mlx5/core/esw/bridge_priv.h
0.377 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0156-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-esw.patch
0.377 patching file drivers/net/ethernet/mellanox/mlx5/core/esw/devlink_port.c
0.378 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0157-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-esw.patch
0.378 patching file drivers/net/ethernet/mellanox/mlx5/core/esw/ipsec.c
0.379 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0158-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-esw.patch
0.379 patching file drivers/net/ethernet/mellanox/mlx5/core/esw/qos.c
0.380 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0159-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-esw.patch
0.380 patching file drivers/net/ethernet/mellanox/mlx5/core/esw/qos.h
0.380 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0160-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-esw.patch
0.381 patching file drivers/net/ethernet/mellanox/mlx5/core/esw/vf_meter.c
0.381 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0161-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-esw.patch
0.382 patching file drivers/net/ethernet/mellanox/mlx5/core/eswitch.h
0.382 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0162-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-esw.patch
0.383 patching file drivers/net/ethernet/mellanox/mlx5/core/eswitch_devlink_compat.c
0.383 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0163-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-esw.patch
0.384 patching file drivers/net/ethernet/mellanox/mlx5/core/eswitch_offloads.c
0.384 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0164-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-fs_.patch
0.385 patching file drivers/net/ethernet/mellanox/mlx5/core/fs_core.h
0.385 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0165-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-fs_.patch
0.386 patching file drivers/net/ethernet/mellanox/mlx5/core/fs_counters.c
0.386 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0166-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-fw..patch
0.386 patching file drivers/net/ethernet/mellanox/mlx5/core/fw.c
0.387 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0167-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-fw_.patch
0.387 patching file drivers/net/ethernet/mellanox/mlx5/core/fw_reset.c
0.388 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0168-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-fw_.patch
0.388 patching file drivers/net/ethernet/mellanox/mlx5/core/fw_reset.h
0.388 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0169-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-hwm.patch
0.389 patching file drivers/net/ethernet/mellanox/mlx5/core/hwmon.c
0.389 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0170-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-ipo.patch
0.390 patching file drivers/net/ethernet/mellanox/mlx5/core/ipoib/ethtool.c
0.390 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0171-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-ipo.patch
0.391 patching file drivers/net/ethernet/mellanox/mlx5/core/ipoib/ipoib.c
0.391 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0172-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-ipo.patch
0.392 patching file drivers/net/ethernet/mellanox/mlx5/core/ipoib/ipoib.h
0.392 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0173-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-ipo.patch
0.393 patching file drivers/net/ethernet/mellanox/mlx5/core/ipoib/ipoib_vlan.c
0.393 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0174-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-lag.patch
0.393 patching file drivers/net/ethernet/mellanox/mlx5/core/lag/lag.h
0.394 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0175-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-lag.patch
0.394 patching file drivers/net/ethernet/mellanox/mlx5/core/lag/mp.c
0.394 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0176-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-lag.patch
0.395 patching file drivers/net/ethernet/mellanox/mlx5/core/lag/mp.h
0.395 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0177-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-lag.patch
0.396 patching file drivers/net/ethernet/mellanox/mlx5/core/lag/mpesw.c
0.396 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0178-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-lag.patch
0.397 patching file drivers/net/ethernet/mellanox/mlx5/core/lag/port_sel.c
0.397 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0179-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-lag.patch
0.397 patching file drivers/net/ethernet/mellanox/mlx5/core/lag/port_sel.h
0.398 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0180-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-lib.patch
0.398 patching file drivers/net/ethernet/mellanox/mlx5/core/lib/clock.h
0.398 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0181-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-lib.patch
0.399 patching file drivers/net/ethernet/mellanox/mlx5/core/lib/geneve.h
0.399 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0182-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-lib.patch
0.400 patching file drivers/net/ethernet/mellanox/mlx5/core/lib/gid.c
0.400 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0183-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-lib.patch
0.400 patching file drivers/net/ethernet/mellanox/mlx5/core/lib/mpfs.c
0.401 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0184-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-lib.patch
0.401 patching file drivers/net/ethernet/mellanox/mlx5/core/lib/mpfs.h
0.401 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0185-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-lib.patch
0.402 patching file drivers/net/ethernet/mellanox/mlx5/core/lib/tout.c
0.402 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0186-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-lib.patch
0.403 patching file drivers/net/ethernet/mellanox/mlx5/core/lib/vxlan.c
0.403 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0187-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-pci.patch
0.404 patching file drivers/net/ethernet/mellanox/mlx5/core/pci_irq.c
0.404 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0188-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-por.patch
0.404 patching file drivers/net/ethernet/mellanox/mlx5/core/port.c
0.405 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0189-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-sf-.patch
0.405 patching file drivers/net/ethernet/mellanox/mlx5/core/sf/diag/vhca_tracepoint.h
0.406 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0190-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-sf-.patch
0.406 patching file drivers/net/ethernet/mellanox/mlx5/core/sf/hw_table.c
0.406 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0191-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-sf-.patch
0.407 patching file drivers/net/ethernet/mellanox/mlx5/core/sf/sf.h
0.407 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0192-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-sf-.patch
0.408 patching file drivers/net/ethernet/mellanox/mlx5/core/sf/vhca_event.c
0.408 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0193-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-sri.patch
0.408 patching file drivers/net/ethernet/mellanox/mlx5/core/sriov.c
0.409 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0194-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-sri.patch
0.409 patching file drivers/net/ethernet/mellanox/mlx5/core/sriov_sysfs.c
0.410 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0195-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-ste.patch
0.410 patching file drivers/net/ethernet/mellanox/mlx5/core/steering/dr_dbg.c
0.411 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0196-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-ste.patch
0.411 patching file drivers/net/ethernet/mellanox/mlx5/core/steering/dr_icm_pool.c
0.411 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0197-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-ste.patch
0.412 patching file drivers/net/ethernet/mellanox/mlx5/core/steering/dr_send.c
0.412 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0198-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-uar.patch
0.413 patching file drivers/net/ethernet/mellanox/mlx5/core/uar.c
0.413 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0199-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-vpo.patch
0.414 patching file drivers/net/ethernet/mellanox/mlx5/core/vport.c
0.414 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0200-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-wq..patch
0.414 patching file drivers/net/ethernet/mellanox/mlx5/core/wq.h
0.415 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0201-BACKPORT-drivers-net-ethernet-mellanox-mlxfw-mlxfw.h.patch
0.415 patching file drivers/net/ethernet/mellanox/mlxfw/mlxfw.h
0.415 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0202-BACKPORT-drivers-net-ethernet-mellanox-mlxfw-mlxfw_f.patch
0.416 patching file drivers/net/ethernet/mellanox/mlxfw/mlxfw_fsm.c
0.416 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0203-BACKPORT-drivers-net-ethernet-mellanox-mlxfw-mlxfw_m.patch
0.417 patching file drivers/net/ethernet/mellanox/mlxfw/mlxfw_mfa2.c
0.417 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0204-BACKPORT-drivers-nvme-host-auth.c.patch
0.418 patching file drivers/nvme/host/auth.c
0.418 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0205-BACKPORT-drivers-nvme-host-fabrics.h.patch
0.418 patching file drivers/nvme/host/fabrics.h
0.419 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0206-BACKPORT-drivers-nvme-host-fault_inject.c.patch
0.419 patching file drivers/nvme/host/fault_inject.c
0.419 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0207-BACKPORT-drivers-nvme-host-hwmon.c.patch
0.420 patching file drivers/nvme/host/hwmon.c
0.420 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0208-BACKPORT-drivers-nvme-host-nvfs-dma.h.patch
0.421 patching file drivers/nvme/host/nvfs-dma.h
0.421 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0209-BACKPORT-drivers-nvme-host-nvfs-rdma.h.patch
0.421 patching file drivers/nvme/host/nvfs-rdma.h
0.421 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0210-BACKPORT-drivers-nvme-host-pr.c.patch
0.422 patching file drivers/nvme/host/pr.c
0.422 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0211-BACKPORT-drivers-nvme-host-trace.h.patch
0.423 patching file drivers/nvme/host/trace.h
0.423 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0212-BACKPORT-drivers-nvme-target-admin-cmd.c.patch
0.423 patching file drivers/nvme/target/admin-cmd.c
0.424 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0213-BACKPORT-drivers-nvme-target-auth.c.patch
0.424 patching file drivers/nvme/target/auth.c
0.424 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0214-BACKPORT-drivers-nvme-target-discovery.c.patch
0.425 patching file drivers/nvme/target/discovery.c
0.425 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0215-BACKPORT-drivers-nvme-target-fabrics-cmd-auth.c.patch
0.426 patching file drivers/nvme/target/fabrics-cmd-auth.c
0.426 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0216-BACKPORT-drivers-nvme-target-io-cmd-file.c.patch
0.427 patching file drivers/nvme/target/io-cmd-file.c
0.427 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0217-BACKPORT-drivers-nvme-target-passthru.c.patch
0.427 patching file drivers/nvme/target/passthru.c
0.428 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0218-BACKPORT-drivers-nvme-target-rdma_offload.c.patch
0.428 patching file drivers/nvme/target/rdma_offload.c
0.428 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0219-BACKPORT-drivers-nvme-target-tcp.c.patch
0.429 patching file drivers/nvme/target/tcp.c
0.429 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0220-BACKPORT-drivers-nvme-target-trace.h.patch
0.430 patching file drivers/nvme/target/trace.h
0.430 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0221-BACKPORT-drivers-nvme-target-zns.c.patch
0.431 patching file drivers/nvme/target/zns.c
0.431 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0222-BACKPORT-drivers-scsi-scsi_priv.h.patch
0.431 patching file drivers/scsi/scsi_priv.h
0.432 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0223-BACKPORT-drivers-scsi-scsi_transport_srp.c.patch
0.432 patching file drivers/scsi/scsi_transport_srp.c
0.432 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0224-BACKPORT-drivers-vdpa-mlx5-core-mlx5_vdpa.h.patch
0.433 patching file drivers/vdpa/mlx5/core/mlx5_vdpa.h
0.433 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0225-BACKPORT-drivers-vdpa-mlx5-net-debug.c.patch
0.434 patching file drivers/vdpa/mlx5/net/debug.c
0.434 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0226-BACKPORT-drivers-vdpa-mlx5-net-mlx5_vnet.h.patch
0.435 patching file drivers/vdpa/mlx5/net/mlx5_vnet.h
0.435 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0227-BACKPORT-drivers-vfio-pci-mlx5-cmd.c.patch
0.435 patching file drivers/vfio/pci/mlx5/cmd.c
0.436 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0228-BACKPORT-drivers-vfio-pci-mlx5-cmd.h.patch
0.436 patching file drivers/vfio/pci/mlx5/cmd.h
0.436 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0229-BACKPORT-drivers-vfio-pci-mlx5-main.c.patch
0.437 patching file drivers/vfio/pci/mlx5/main.c
0.437 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0230-BACKPORT-include-linux-auxiliary_bus.h.patch
0.438 patching file include/linux/auxiliary_bus.h
0.438 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0231-BACKPORT-include-linux-mlx5-fs.h.patch
0.438 patching file include/linux/mlx5/fs.h
0.439 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0232-BACKPORT-include-linux-mlx5-port.h.patch
0.439 patching file include/linux/mlx5/port.h
0.439 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0234-BACKPORT-include-linux-mod_devicetable.h.patch
0.440 patching file include/linux/mod_devicetable.h
0.440 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0235-BACKPORT-include-linux-nvme-fc-driver.h.patch
0.441 patching file include/linux/nvme-fc-driver.h
0.441 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0236-BACKPORT-include-linux-nvme-rdma.h.patch
0.441 patching file include/linux/nvme-rdma.h
0.442 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0237-BACKPORT-include-linux-nvme.h.patch
0.442 patching file include/linux/nvme.h
0.442 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0238-BACKPORT-include-net-xdp_sock_drv.h.patch
0.443 patching file include/net/xdp_sock_drv.h
0.443 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0239-BACKPORT-include-net-xfrm.h.patch
0.444 patching file include/net/xfrm.h
0.444 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0240-BACKPORT-include-rdma-ib_addr.h.patch
0.444 patching file include/rdma/ib_addr.h
0.445 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0241-BACKPORT-include-rdma-ib_umem.h.patch
0.445 patching file include/rdma/ib_umem.h
0.445 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0242-BACKPORT-include-rdma-ib_umem_odp.h.patch
0.446 patching file include/rdma/ib_umem_odp.h
0.446 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0243-BACKPORT-include-rdma-ib_verbs.h.patch
0.447 patching file include/rdma/ib_verbs.h
0.447 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0244-BACKPORT-include-rdma-rdma_counter.h.patch
0.448 patching file include/rdma/rdma_counter.h
0.448 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0245-BACKPORT-include-rdma-rdma_netlink.h.patch
0.448 patching file include/rdma/rdma_netlink.h
0.448 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0246-BACKPORT-include-rdma-uverbs_ioctl.h.patch
0.449 patching file include/rdma/uverbs_ioctl.h
0.449 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0247-BACKPORT-include-scsi-scsi_transport_srp.h.patch
0.450 patching file include/scsi/scsi_transport_srp.h
0.450 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0248-BACKPORT-include-trace-events-ib_mad.h.patch
0.451 patching file include/trace/events/ib_mad.h
0.451 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0249-BACKPORT-include-trace-events-ib_umad.h.patch
0.451 patching file include/trace/events/ib_umad.h
0.451 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0250-BACKPORT-include-trace-events-rpcrdma.h.patch
0.452 patching file include/trace/events/rpcrdma.h
0.452 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0251-BACKPORT-net-mlxdevm-mlxdevm.c.patch
0.453 patching file net/mlxdevm/mlxdevm.c
0.453 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0258-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-dia.patch
0.454 patching file drivers/net/ethernet/mellanox/mlx5/core/diag/fw_tracer.c
0.454 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0259-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-dia.patch
0.455 patching file drivers/net/ethernet/mellanox/mlx5/core/diag/reporter_vnic.c
0.455 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0260-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-dia.patch
0.456 patching file drivers/net/ethernet/mellanox/mlx5/core/diag/reporter_vnic.h
0.456 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0261-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.456 patching file drivers/net/ethernet/mellanox/mlx5/core/en/channels.c
0.457 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0262-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.457 patching file drivers/net/ethernet/mellanox/mlx5/core/en/devlink.c
0.457 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0263-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-dpl.patch
0.458 patching file drivers/net/ethernet/mellanox/mlx5/core/dpll.c
0.458 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0264-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.459 patching file drivers/net/ethernet/mellanox/mlx5/core/en/rep/tc.c
0.459 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0265-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.460 patching file drivers/net/ethernet/mellanox/mlx5/core/en/rx_res.c
0.460 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0266-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.461 patching file drivers/net/ethernet/mellanox/mlx5/core/en_accel/ktls.h
0.461 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0267-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.462 patching file drivers/net/ethernet/mellanox/mlx5/core/en_accel/ktls_rx.c
0.462 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0268-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.462 patching file drivers/net/ethernet/mellanox/mlx5/core/en_dcbnl.c
0.463 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0269-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-fs_.patch
0.464 patching file drivers/net/ethernet/mellanox/mlx5/core/fs_core.c
0.464 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0270-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-lib.patch
0.465 patching file drivers/net/ethernet/mellanox/mlx5/core/lib/eq.h
0.465 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0271-BACKPORT-drivers-vdpa-mlx5-core-mr.c.patch
0.466 patching file drivers/vdpa/mlx5/core/mr.c
0.466 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0272-BACKPORT-drivers-vdpa-mlx5-core-resources.c.patch
0.466 patching file drivers/vdpa/mlx5/core/resources.c
0.467 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0273-BACKPORT-drivers-vdpa-mlx5-net-mlx5_vnet.c.patch
0.467 patching file drivers/vdpa/mlx5/net/mlx5_vnet.c
0.468 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0274-BACKPORT-include-linux-mlx5-driver.h.patch
0.468 patching file include/linux/mlx5/driver.h
0.469 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0275-BACKPORT-include-rdma-lag.h.patch
0.469 patching file include/rdma/lag.h
0.469 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0276-BACKPORT-drivers-infiniband-core-cm.c.patch
0.470 patching file drivers/infiniband/core/cm.c
0.471 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0277-BACKPORT-drivers-infiniband-core-iwcm.c.patch
0.471 patching file drivers/infiniband/core/iwcm.c
0.471 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0278-BACKPORT-drivers-infiniband-core-ucma.c.patch
0.472 patching file drivers/infiniband/core/ucma.c
0.472 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0279-BACKPORT-drivers-infiniband-hw-mlx5-devx.c.patch
0.473 patching file drivers/infiniband/hw/mlx5/devx.c
0.473 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0280-BACKPORT-drivers-infiniband-hw-mlx5-mr.c.patch
0.474 patching file drivers/infiniband/hw/mlx5/mr.c
0.474 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0281-BACKPORT-drivers-infiniband-ulp-ipoib-ipoib_ib.c.patch
0.475 patching file drivers/infiniband/ulp/ipoib/ipoib_ib.c
0.475 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0282-BACKPORT-drivers-infiniband-ulp-ipoib-ipoib_main.c.patch
0.476 patching file drivers/infiniband/ulp/ipoib/ipoib_main.c
0.476 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0283-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en..patch
0.477 patching file drivers/net/ethernet/mellanox/mlx5/core/en.h
0.477 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0284-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.478 patching file drivers/net/ethernet/mellanox/mlx5/core/en/xsk/tx.c
0.478 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0285-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.479 patching file drivers/net/ethernet/mellanox/mlx5/core/en_arfs.c
0.479 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0286-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.480 patching file drivers/net/ethernet/mellanox/mlx5/core/en_rep.c
0.480 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0287-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.481 patching file drivers/net/ethernet/mellanox/mlx5/core/en_rx.c
0.482 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0288-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.482 patching file drivers/net/ethernet/mellanox/mlx5/core/en_tc.c
0.483 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0289-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-dev.patch
0.484 patching file drivers/net/ethernet/mellanox/mlx5/core/dev.c
0.484 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0290-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.485 patching file drivers/net/ethernet/mellanox/mlx5/core/en/health.h
0.485 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0291-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.486 patching file drivers/net/ethernet/mellanox/mlx5/core/en/xdp.h
0.486 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0292-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.487 patching file drivers/net/ethernet/mellanox/mlx5/core/en/xsk/setup.c
0.487 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0293-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-esw.patch
0.488 patching file drivers/net/ethernet/mellanox/mlx5/core/eswitch.c
0.488 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0294-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-lag.patch
0.489 patching file drivers/net/ethernet/mellanox/mlx5/core/lag/lag.c
0.489 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0295-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-lib.patch
0.490 patching file drivers/net/ethernet/mellanox/mlx5/core/lib/clock.c
0.490 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0296-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-mai.patch
0.491 patching file drivers/net/ethernet/mellanox/mlx5/core/main.c
0.491 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0297-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-mlx.patch
0.492 patching file drivers/net/ethernet/mellanox/mlx5/core/mlx5_core.h
0.492 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0298-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-sf-.patch
0.493 patching file drivers/net/ethernet/mellanox/mlx5/core/sf/devlink.c
0.493 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0299-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.493 patching file drivers/net/ethernet/mellanox/mlx5/core/en/health.c
0.494 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0300-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.494 patching file drivers/net/ethernet/mellanox/mlx5/core/en/reporter_rx.c
0.495 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0301-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.495 patching file drivers/net/ethernet/mellanox/mlx5/core/en/xsk/pool.c
0.496 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0302-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-hea.patch
0.496 patching file drivers/net/ethernet/mellanox/mlx5/core/health.c
0.497 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0303-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-sf-.patch
0.497 patching file drivers/net/ethernet/mellanox/mlx5/core/sf/dev/driver.c
0.498 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0304-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-dev.patch
0.498 patching file drivers/net/ethernet/mellanox/mlx5/core/devlink.c
0.499 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0305-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.499 patching file drivers/net/ethernet/mellanox/mlx5/core/en/reporter_tx.c
0.500 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0305-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-mlx.patch
0.500 patching file drivers/net/ethernet/mellanox/mlx5/core/mlx5_devm.c
0.501 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0306-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.501 patching file drivers/net/ethernet/mellanox/mlx5/core/en/xdp.c
0.502 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0306-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-sf-.patch
0.502 patching file drivers/net/ethernet/mellanox/mlx5/core/sf/dev/dev.h
0.502 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0307-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.503 patching file drivers/net/ethernet/mellanox/mlx5/core/en/xsk/rx.c
0.503 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0307-BACKPORT-include-linux-mlx5-device.h.patch
0.504 patching file include/linux/mlx5/device.h
0.504 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0308-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.505 patching file drivers/net/ethernet/mellanox/mlx5/core/en_accel/ipsec.c
0.505 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0309-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.506 patching file drivers/net/ethernet/mellanox/mlx5/core/en_ethtool.c
0.506 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0309-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-ste.patch
0.507 patching file drivers/net/ethernet/mellanox/mlx5/core/steering/dr_action.c
0.507 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0310-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en_.patch
0.508 patching file drivers/net/ethernet/mellanox/mlx5/core/en_main.c
0.510 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0310-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-lib.patch
0.510 patching file drivers/net/ethernet/mellanox/mlx5/core/lib/devcom.c
0.511 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0310-BACKPORT-drivers-nvme-host-apple.c.patch
0.511 patching file drivers/nvme/host/apple.c
0.511 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0310-BACKPORT-net-sunrpc-xprtrdma-backchannel.c.patch
0.512 patching file net/sunrpc/xprtrdma/backchannel.c
0.512 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0311-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-lib.patch
0.513 patching file drivers/net/ethernet/mellanox/mlx5/core/lib/sd.c
0.513 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0311-BACKPORT-drivers-nvme-host-fc.c.patch
0.514 patching file drivers/nvme/host/fc.c
0.514 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0311-BACKPORT-net-sunrpc-xprtrdma-frwr_ops.c.patch
0.515 patching file net/sunrpc/xprtrdma/frwr_ops.c
0.515 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0312-BACKPORT-drivers-nvme-target-configfs.c.patch
0.516 patching file drivers/nvme/target/configfs.c
0.516 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0312-BACKPORT-net-sunrpc-xprtrdma-module.c.patch
0.517 patching file net/sunrpc/xprtrdma/module.c
0.517 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0313-BACKPORT-drivers-nvme-host-sysfs.c.patch
0.517 patching file drivers/nvme/host/sysfs.c
0.517 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0313-BACKPORT-net-sunrpc-xprtrdma-rpc_rdma.c.patch
0.518 patching file net/sunrpc/xprtrdma/rpc_rdma.c
0.518 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0314-BACKPORT-net-sunrpc-xprtrdma-svc_rdma_pcl.c.patch
0.519 patching file net/sunrpc/xprtrdma/svc_rdma_pcl.c
0.519 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0314-BACKPORTS-drivers-nvme-common-auth.c.patch
0.520 patching file drivers/nvme/common/auth.c
0.520 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0315-BACKPORT-drivers-nvme-target-io-cmd-bdev.c.patch
0.520 patching file drivers/nvme/target/io-cmd-bdev.c
0.521 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0315-BACKPORT-net-sunrpc-xprtrdma-transport.c.patch
0.521 patching file net/sunrpc/xprtrdma/transport.c
0.522 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0316-BACKPORT-drivers-nvme-target-loop.c.patch
0.522 patching file drivers/nvme/target/loop.c
0.522 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0316-BACKPORT-net-sunrpc-xprtrdma-verbs.c.patch
0.523 patching file net/sunrpc/xprtrdma/verbs.c
0.523 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0317-BACKPORT-drivers-nvme-target-nvmet.h.patch
0.524 patching file drivers/nvme/target/nvmet.h
0.524 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0317-BACKPORT-net-sunrpc-xprtrdma-xprt_rdma.h.patch
0.525 patching file net/sunrpc/xprtrdma/xprt_rdma.h
0.525 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0318-BACKPORT-drivers-nvme-host-tcp.c.patch
0.526 patching file drivers/nvme/host/tcp.c
0.526 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0318-BACKPORT-net-sunrpc-xprtrdma-svc_rdma_transport.c.patch
0.527 patching file net/sunrpc/xprtrdma/svc_rdma_transport.c
0.527 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0319-BACKPORT-drivers-nvme-target-core.c.patch
0.527 patching file drivers/nvme/target/core.c
0.528 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0319-BACKPORT-net-sunrpc-xprtrdma-svc_rdma.c.patch
0.528 patching file net/sunrpc/xprtrdma/svc_rdma.c
0.528 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0320-BACKPORT-drivers-nvme-target-fc.c.patch
0.529 patching file drivers/nvme/target/fc.c
0.529 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0320-BACKPORT-net-sunrpc-xprtrdma-svc_rdma_backchannel.c.patch
0.530 patching file net/sunrpc/xprtrdma/svc_rdma_backchannel.c
0.530 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0321-BACKPORT-drivers-nvme-target-rdma.c.patch
0.531 patching file drivers/nvme/target/rdma.c
0.531 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0321-BACKPORT-include-linux-sunrpc-svc_rdma.h.patch
0.532 patching file include/linux/sunrpc/svc_rdma.h
0.532 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0322-BACKPORT-drivers-nvme-host-pci.c.patch
0.533 patching file drivers/nvme/host/pci.c
0.533 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0322-BACKPORT-net-sunrpc-xprtrdma-svc_rdma_recvfrom.c.patch
0.534 patching file net/sunrpc/xprtrdma/svc_rdma_recvfrom.c
0.534 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0323-BACKPORT-drivers-nvme-host-rdma.c.patch
0.535 patching file drivers/nvme/host/rdma.c
0.535 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0323-BACKPORT-net-sunrpc-xprtrdma-svc_rdma_sendto.c.patch
0.536 patching file net/sunrpc/xprtrdma/svc_rdma_sendto.c
0.536 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0324-BACKPORT-drivers-nvme-target-fcloop.c.patch
0.537 patching file drivers/nvme/target/fcloop.c
0.537 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0324-BACKPORT-net-sunrpc-xprtrdma-svc_rdma_rw.c.patch
0.538 patching file net/sunrpc/xprtrdma/svc_rdma_rw.c
0.538 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0325-BACKPORT-drivers-nvme-host-fabrics.c.patch
0.539 patching file drivers/nvme/host/fabrics.c
0.539 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0326-BACKPORT-drivers-nvme-host-zns.c.patch
0.540 patching file drivers/nvme/host/zns.c
0.540 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0327-BACKPORT-drivers-nvme-host-nvme.h.patch
0.540 patching file drivers/nvme/host/nvme.h
0.541 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0328-BACKPORT-drivers-nvme-host-core.c.patch
0.541 patching file drivers/nvme/host/core.c
0.542 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0329-BACKPORT-drivers-nvme-host-ioctl.c.patch
0.543 patching file drivers/nvme/host/ioctl.c
0.543 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0330-BACKPORT-drivers-nvme-host-multipath.c.patch
0.544 patching file drivers/nvme/host/multipath.c
0.545 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0346-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-dia.patch
0.545 patching file drivers/net/ethernet/mellanox/mlx5/core/diag/cmd_tracepoint.h
0.545 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0347-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-dia.patch
0.546 patching file drivers/net/ethernet/mellanox/mlx5/core/diag/en_rep_tracepoint.h
0.546 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0348-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-dia.patch
0.547 patching file drivers/net/ethernet/mellanox/mlx5/core/diag/fw_tracer_tracepoint.h
0.547 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0349-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-esw.patch
0.548 patching file drivers/net/ethernet/mellanox/mlx5/core/esw/diag/qos_tracepoint.h
0.548 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0350-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-sf-.patch
0.548 patching file drivers/net/ethernet/mellanox/mlx5/core/sf/dev/diag/dev_tracepoint.h
0.549 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0351-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-sf-.patch
0.549 patching file drivers/net/ethernet/mellanox/mlx5/core/sf/diag/sf_tracepoint.h
0.549 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0352-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.550 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc_tun_gre.c
0.550 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0353-BACKPORT-drivers-fwctl-main.c.patch
0.551 patching file drivers/fwctl/main.c
0.551 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0354-BACKPORT-drivers-fwctl-mlx5-main.c.patch
0.552 patching file drivers/fwctl/mlx5/main.c
0.552 	/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/backports/0355-BACKPORT-drivers-net-ethernet-mellanox-mlx5-core-en-.patch
0.552 patching file drivers/net/ethernet/mellanox/mlx5/core/en/tc/act/sample.c
0.640 Created configure.mk.kernel:
0.640 # Current working directory
0.640 CWD=/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1
0.640 BACKPORT_INCLUDES=
0.640
0.640 # Kernel level
0.640 KVERSION=6.10.7-arch1-1
0.640 ARCH=x86_64
0.640 MODULES_DIR=/lib/modules/6.10.7-arch1-1/updates
0.640 KSRC=/src
0.640 KSRC_OBJ=/src
0.640 KLIB_BUILD=/src
0.640 prefix=/usr
0.640
0.640 AUTOCONF_H=/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/include/generated/autoconf.h
0.640
0.640 WITH_MAKE_PARAMS=
0.640
0.640 CONFIG_AUXILIARY_BUS=
0.640 CONFIG_AUXILIARY_BUS=
0.640 CONFIG_BACKPORT_LRO=m
0.640 CONFIG_BACKPORT_LRO=m
0.640 CONFIG_BF_DEVICE_EMULATION=
0.640 CONFIG_BF_DEVICE_EMULATION=
0.640 CONFIG_BF_POWER_FAILURE_EVENT=
0.640 CONFIG_BF_POWER_FAILURE_EVENT=
0.640 CONFIG_BLK_DEV_NVME=
0.640 CONFIG_BLK_DEV_NVME=
0.640 CONFIG_COMPAT_KOBJECT_BACKPORT=
0.640 CONFIG_COMPAT_KOBJECT_BACKPORT=
0.640 CONFIG_COMPAT_VERSION=
0.640 CONFIG_COMPAT_VERSION=
0.640 CONFIG_DEBUG_INFO=y
0.640 CONFIG_DEBUG_INFO=y
0.640 CONFIG_ENABLE_BASECODE_EXTRAS=y
0.640 CONFIG_ENABLE_BASECODE_EXTRAS=y
0.640 CONFIG_ENABLE_MLX5_FS_DEBUGFS=
0.640 CONFIG_ENABLE_MLX5_FS_DEBUGFS=
0.640 CONFIG_ENABLE_VFIO=y
0.640 CONFIG_ENABLE_VFIO=y
0.640 CONFIG_ENABLE_XDP=y
0.640 CONFIG_ENABLE_XDP=y
0.640 CONFIG_FWCTL=m
0.640 CONFIG_FWCTL=m
0.640 CONFIG_FWCTL_MLX5=m
0.640 CONFIG_FWCTL_MLX5=m
0.640 CONFIG_GPU_DIRECT_STORAGE=
0.640 CONFIG_GPU_DIRECT_STORAGE=
0.640 CONFIG_INFINIBAND=m
0.640 CONFIG_INFINIBAND=m
0.640 CONFIG_INFINIBAND_ADDR_TRANS=y
0.640 CONFIG_INFINIBAND_ADDR_TRANS=y
0.640 CONFIG_INFINIBAND_ADDR_TRANS_CONFIGFS=y
0.640 CONFIG_INFINIBAND_ADDR_TRANS_CONFIGFS=y
0.640 CONFIG_INFINIBAND_CORE_DUMMY=
0.640 CONFIG_INFINIBAND_CORE_DUMMY=
0.640 CONFIG_INFINIBAND_IPOIB=m
0.640 CONFIG_INFINIBAND_IPOIB=m
0.640 CONFIG_INFINIBAND_IPOIB_CM=y
0.640 CONFIG_INFINIBAND_IPOIB_CM=y
0.640 CONFIG_INFINIBAND_IPOIB_DEBUG=y
0.640 CONFIG_INFINIBAND_IPOIB_DEBUG=y
0.640 CONFIG_INFINIBAND_IPOIB_DEBUG_DATA=
0.640 CONFIG_INFINIBAND_IPOIB_DEBUG_DATA=
0.640 CONFIG_INFINIBAND_ISER=m
0.640 CONFIG_INFINIBAND_ISER=m
0.640 CONFIG_INFINIBAND_ISERT=
0.640 CONFIG_INFINIBAND_ISERT=
0.640 CONFIG_INFINIBAND_ISERT_DUMMY=
0.640 CONFIG_INFINIBAND_ISERT_DUMMY=
0.640 CONFIG_INFINIBAND_ISER_DUMMY=
0.640 CONFIG_INFINIBAND_ISER_DUMMY=
0.640 CONFIG_INFINIBAND_MADEYE=
0.640 CONFIG_INFINIBAND_MADEYE=
0.640 CONFIG_INFINIBAND_ON_DEMAND_PAGING=y
0.640 CONFIG_INFINIBAND_ON_DEMAND_PAGING=y
0.640 CONFIG_INFINIBAND_PA_MR=
0.640 CONFIG_INFINIBAND_PA_MR=
0.640 CONFIG_INFINIBAND_SDP_DEBUG=
0.640 CONFIG_INFINIBAND_SDP_DEBUG=
0.640 CONFIG_INFINIBAND_SDP_DEBUG_DATA=
0.640 CONFIG_INFINIBAND_SDP_DEBUG_DATA=
0.640 CONFIG_INFINIBAND_SDP_RECV_ZCOPY=
0.640 CONFIG_INFINIBAND_SDP_RECV_ZCOPY=
0.640 CONFIG_INFINIBAND_SDP_SEND_ZCOPY=
0.640 CONFIG_INFINIBAND_SDP_SEND_ZCOPY=
0.640 CONFIG_INFINIBAND_SRP=m
0.640 CONFIG_INFINIBAND_SRP=m
0.640 CONFIG_INFINIBAND_SRP_DUMMY=
0.640 CONFIG_INFINIBAND_SRP_DUMMY=
0.640 CONFIG_INFINIBAND_USER_ACCESS=m
0.640 CONFIG_INFINIBAND_USER_ACCESS=m
0.640 CONFIG_INFINIBAND_USER_ACCESS_UCM=m
0.640 CONFIG_INFINIBAND_USER_ACCESS_UCM=m
0.640 CONFIG_INFINIBAND_USER_MAD=m
0.640 CONFIG_INFINIBAND_USER_MAD=m
0.640 CONFIG_INFINIBAND_USER_MEM=y
0.640 CONFIG_INFINIBAND_USER_MEM=y
0.640 CONFIG_INFINIBAND_WQE_FORMAT=
0.640 CONFIG_INFINIBAND_WQE_FORMAT=
0.640 CONFIG_IPOIB_ALL_MULTI=
0.640 CONFIG_IPOIB_ALL_MULTI=
0.640 CONFIG_IPOIB_VERSION=
0.640 CONFIG_IPOIB_VERSION=
0.640 CONFIG_IS_MARINER=
0.640 CONFIG_IS_MARINER=
0.640 CONFIG_MEMTRACK=
0.640 CONFIG_MEMTRACK=
0.640 CONFIG_MLNX_BLOCK_REQUEST_MODULE=
0.640 CONFIG_MLNX_BLOCK_REQUEST_MODULE=
0.640 CONFIG_MLX5_ACCEL=y
0.640 CONFIG_MLX5_ACCEL=y
0.640 CONFIG_MLX5_BRIDGE=y
0.640 CONFIG_MLX5_BRIDGE=y
0.640 CONFIG_MLX5_CLS_ACT=y
0.640 CONFIG_MLX5_CLS_ACT=y
0.640 CONFIG_MLX5_CORE=m
0.640 CONFIG_MLX5_CORE=m
0.640 CONFIG_MLX5_CORE_EN=y
0.640 CONFIG_MLX5_CORE_EN=y
0.640 CONFIG_MLX5_CORE_EN_DCB=y
0.640 CONFIG_MLX5_CORE_EN_DCB=y
0.640 CONFIG_MLX5_CORE_IPOIB=y
0.640 CONFIG_MLX5_CORE_IPOIB=y
0.640 CONFIG_MLX5_DEBUG=y
0.640 CONFIG_MLX5_DEBUG=y
0.640 CONFIG_MLX5_EN_ARFS=y
0.640 CONFIG_MLX5_EN_ARFS=y
0.640 CONFIG_MLX5_EN_IPSEC=
0.640 CONFIG_MLX5_EN_IPSEC=
0.640 CONFIG_MLX5_EN_RXNFC=y
0.640 CONFIG_MLX5_EN_RXNFC=y
0.640 CONFIG_MLX5_EN_SPECIAL_SQ=y
0.640 CONFIG_MLX5_EN_SPECIAL_SQ=y
0.640 CONFIG_MLX5_EN_TLS=
0.640 CONFIG_MLX5_EN_TLS=
0.640 CONFIG_MLX5_ESWITCH=y
0.640 CONFIG_MLX5_ESWITCH=y
0.640 CONFIG_MLX5_FPGA=
0.640 CONFIG_MLX5_FPGA=
0.640 CONFIG_MLX5_FPGA_IPSEC=
0.640 CONFIG_MLX5_FPGA_IPSEC=
0.640 CONFIG_MLX5_FPGA_TLS=
0.640 CONFIG_MLX5_FPGA_TLS=
0.640 CONFIG_MLX5_INFINIBAND=m
0.640 CONFIG_MLX5_INFINIBAND=m
0.640 CONFIG_MLX5_IPSEC=
0.640 CONFIG_MLX5_IPSEC=
0.640 CONFIG_MLX5_MACSEC=
0.640 CONFIG_MLX5_MACSEC=
0.640 CONFIG_MLX5_MPFS=y
0.640 CONFIG_MLX5_MPFS=y
0.640 CONFIG_MLX5_SF=y
0.640 CONFIG_MLX5_SF=y
0.640 CONFIG_MLX5_SF_CFG=
0.640 CONFIG_MLX5_SF_CFG=
0.640 CONFIG_MLX5_SF_MANAGER=y
0.640 CONFIG_MLX5_SF_MANAGER=y
0.640 CONFIG_MLX5_SF_SFC=
0.640 CONFIG_MLX5_SF_SFC=
0.640 CONFIG_MLX5_SW_STEERING=y
0.640 CONFIG_MLX5_SW_STEERING=y
0.640 CONFIG_MLX5_TC_CT=
0.640 CONFIG_MLX5_TC_CT=
0.640 CONFIG_MLX5_TC_SAMPLE=y
0.640 CONFIG_MLX5_TC_SAMPLE=y
0.640 CONFIG_MLX5_TLS=
0.640 CONFIG_MLX5_TLS=
0.640 CONFIG_MLX5_VDPA_NET_DUMMY=
0.640 CONFIG_MLX5_VDPA_NET_DUMMY=
0.640 CONFIG_MLXDEVM=m
0.640 CONFIG_MLXDEVM=m
0.640 CONFIG_MLXFW=
0.640 CONFIG_MLXFW=
0.640 CONFIG_NVME_APPLE=
0.640 CONFIG_NVME_APPLE=
0.640 CONFIG_NVME_COMMON=
0.640 CONFIG_NVME_COMMON=
0.640 CONFIG_NVME_CORE=
0.640 CONFIG_NVME_CORE=
0.640 CONFIG_NVME_FABRICS=
0.640 CONFIG_NVME_FABRICS=
0.640 CONFIG_NVME_FC=
0.640 CONFIG_NVME_FC=
0.640 CONFIG_NVME_HOST_AUTH=
0.640 CONFIG_NVME_HOST_AUTH=
0.640 CONFIG_NVME_HOST_DUMMY=
0.640 CONFIG_NVME_HOST_DUMMY=
0.640 CONFIG_NVME_HOST_WITHOUT_FC=
0.640 CONFIG_NVME_HOST_WITHOUT_FC=
0.640 CONFIG_NVME_MULTIPATH=
0.640 CONFIG_NVME_MULTIPATH=
0.640 CONFIG_NVME_POLL=
0.640 CONFIG_NVME_POLL=
0.640 CONFIG_NVME_RDMA=
0.640 CONFIG_NVME_RDMA=
0.640 CONFIG_NVME_TARGET=
0.640 CONFIG_NVME_TARGET=
0.640 CONFIG_NVME_TARGET_DUMMY=
0.640 CONFIG_NVME_TARGET_DUMMY=
0.640 CONFIG_NVME_TARGET_FC=
0.640 CONFIG_NVME_TARGET_FC=
0.640 CONFIG_NVME_TARGET_FCLOOP=
0.640 CONFIG_NVME_TARGET_FCLOOP=
0.640 CONFIG_NVME_TARGET_LOOP=
0.640 CONFIG_NVME_TARGET_LOOP=
0.640 CONFIG_NVME_TARGET_RDMA=
0.640 CONFIG_NVME_TARGET_RDMA=
0.640 CONFIG_NVME_TARGET_TCP=
0.640 CONFIG_NVME_TARGET_TCP=
0.640 CONFIG_NVME_TCP=
0.640 CONFIG_NVME_TCP=
0.640 CONFIG_RDMA_RXE=
0.640 CONFIG_RDMA_RXE=
0.640 CONFIG_RDMA_RXE_DUMMY=
0.640 CONFIG_RDMA_RXE_DUMMY=
0.640 CONFIG_SCSI_ISCSI_ATTRS=m
0.640 CONFIG_SCSI_ISCSI_ATTRS=m
0.640 CONFIG_SCSI_SRP_ATTRS=m
0.640 CONFIG_SCSI_SRP_ATTRS=m
0.640 CONFIG_SUNRPC_XPRT_RDMA=
0.640 CONFIG_SUNRPC_XPRT_RDMA=
0.640 CONFIG_SUNRPC_XPRT_RDMA_DUMMY=
0.640 CONFIG_SUNRPC_XPRT_RDMA_DUMMY=
0.642 Created /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/include/generated/autoconf.h:
0.642 #ifndef __OFED_BUILD__
0.642 #include_next <generated/autoconf.h>
0.642 #define CONFIG_BACKPORT_LRO 1
0.642 #define CONFIG_DEBUG_INFO 1
0.642 #define CONFIG_ENABLE_BASECODE_EXTRAS 1
0.642 #define CONFIG_ENABLE_VFIO 1
0.642 #define CONFIG_ENABLE_XDP 1
0.642 #define CONFIG_FWCTL 1
0.642 #define CONFIG_FWCTL_MLX5 1
0.642 #define CONFIG_INFINIBAND 1
0.642 #define CONFIG_INFINIBAND_ADDR_TRANS 1
0.642 #define CONFIG_INFINIBAND_ADDR_TRANS_CONFIGFS 1
0.642 #define CONFIG_INFINIBAND_IPOIB 1
0.642 #define CONFIG_INFINIBAND_IPOIB_CM 1
0.642 #define CONFIG_INFINIBAND_IPOIB_DEBUG 1
0.642 #define CONFIG_INFINIBAND_ISER 1
0.642 #define CONFIG_SCSI_ISCSI_ATTRS 1
0.642 #define CONFIG_ISCSI_TCP 1
0.642 #define CONFIG_INFINIBAND_ON_DEMAND_PAGING 1
0.642 #define CONFIG_INFINIBAND_SRP 1
0.642 #define CONFIG_INFINIBAND_USER_ACCESS 1
0.642 #define CONFIG_INFINIBAND_USER_ACCESS_UCM 1
0.642 #define CONFIG_INFINIBAND_USER_MAD 1
0.642 #define CONFIG_INFINIBAND_USER_MEM 1
0.642 #define CONFIG_MLX5_ACCEL 1
0.642 #define CONFIG_MLX5_BRIDGE 1
0.642 #define CONFIG_MLX5_CLS_ACT 1
0.642 #define CONFIG_MLX5_CORE 1
0.642 #define CONFIG_MLX5_CORE_EN 1
0.642 #define CONFIG_MLX5_CORE_EN_DCB 1
0.642 #define CONFIG_MLX5_CORE_IPOIB 1
0.642 #define CONFIG_MLX5_DEBUG 1
0.642 #define CONFIG_MLX5_EN_ARFS 1
0.642 #define CONFIG_MLX5_EN_RXNFC 1
0.642 #define CONFIG_MLX5_EN_SPECIAL_SQ 1
0.642 #define CONFIG_MLX5_ESWITCH 1
0.642 #define CONFIG_MLX5_INFINIBAND 1
0.642 #define CONFIG_MLX5_MPFS 1
0.642 #define CONFIG_MLX5_SF 1
0.642 #define CONFIG_MLX5_SF_MANAGER 1
0.642 #define CONFIG_MLX5_SW_STEERING 1
0.642 #define CONFIG_MLX5_TC_SAMPLE 1
0.642 #define CONFIG_MLXDEVM 1
0.642 #define CONFIG_SCSI_ISCSI_ATTRS 1
0.642 #define CONFIG_SCSI_SRP_ATTRS 1
0.642
0.642 #else
0.642 #undef CONFIG_AUXILIARY_BUS
0.642 #undef CONFIG_BACKPORT_LRO
0.642 #undef CONFIG_BF_DEVICE_EMULATION
0.642 #undef CONFIG_BF_POWER_FAILURE_EVENT
0.642 #undef CONFIG_BLK_DEV_NVME
0.642 #undef CONFIG_COMPAT_KOBJECT_BACKPORT
0.642 #undef CONFIG_COMPAT_VERSION
0.642 #undef CONFIG_DEBUG_INFO
0.642 #undef CONFIG_ENABLE_BASECODE_EXTRAS
0.642 #undef CONFIG_ENABLE_MLX5_FS_DEBUGFS
0.642 #undef CONFIG_ENABLE_VFIO
0.642 #undef CONFIG_ENABLE_XDP
0.642 #undef CONFIG_FWCTL
0.642 #undef CONFIG_FWCTL_MLX5
0.642 #undef CONFIG_GPU_DIRECT_STORAGE
0.642 #undef CONFIG_INFINIBAND
0.642 #undef CONFIG_INFINIBAND_ADDR_TRANS
0.642 #undef CONFIG_INFINIBAND_ADDR_TRANS_CONFIGFS
0.642 #undef CONFIG_INFINIBAND_CORE_DUMMY
0.642 #undef CONFIG_INFINIBAND_IPOIB
0.642 #undef CONFIG_INFINIBAND_IPOIB_CM
0.642 #undef CONFIG_INFINIBAND_IPOIB_DEBUG
0.642 #undef CONFIG_INFINIBAND_IPOIB_DEBUG_DATA
0.642 #undef CONFIG_INFINIBAND_ISER
0.642 #undef CONFIG_SCSI_ISCSI_ATTRS
0.642 #undef CONFIG_ISCSI_TCP
0.642 #undef CONFIG_INFINIBAND_ISERT
0.642 #undef CONFIG_INFINIBAND_ISERT_DUMMY
0.642 #undef CONFIG_INFINIBAND_ISER_DUMMY
0.642 #undef CONFIG_INFINIBAND_MADEYE
0.642 #undef CONFIG_INFINIBAND_ON_DEMAND_PAGING
0.642 #undef CONFIG_INFINIBAND_PA_MR
0.642 #undef CONFIG_INFINIBAND_SDP_DEBUG
0.642 #undef CONFIG_INFINIBAND_SDP_DEBUG_DATA
0.642 #undef CONFIG_INFINIBAND_SDP_RECV_ZCOPY
0.642 #undef CONFIG_INFINIBAND_SDP_SEND_ZCOPY
0.642 #undef CONFIG_INFINIBAND_SRP
0.642 #undef CONFIG_INFINIBAND_SRP_DUMMY
0.642 #undef CONFIG_INFINIBAND_USER_ACCESS
0.642 #undef CONFIG_INFINIBAND_USER_ACCESS_UCM
0.642 #undef CONFIG_INFINIBAND_USER_MAD
0.642 #undef CONFIG_INFINIBAND_USER_MEM
0.642 #undef CONFIG_INFINIBAND_WQE_FORMAT
0.642 #undef CONFIG_IPOIB_ALL_MULTI
0.642 #undef CONFIG_IPOIB_VERSION
0.642 #undef CONFIG_IS_MARINER
0.642 #undef CONFIG_MEMTRACK
0.642 #undef CONFIG_MLNX_BLOCK_REQUEST_MODULE
0.642 #undef CONFIG_MLX5_ACCEL
0.642 #undef CONFIG_MLX5_BRIDGE
0.642 #undef CONFIG_MLX5_CLS_ACT
0.642 #undef CONFIG_MLX5_CORE
0.642 #undef CONFIG_MLX5_CORE_EN
0.642 #undef CONFIG_MLX5_CORE_EN_DCB
0.642 #undef CONFIG_MLX5_CORE_IPOIB
0.642 #undef CONFIG_MLX5_DEBUG
0.642 #undef CONFIG_MLX5_EN_ARFS
0.642 #undef CONFIG_MLX5_EN_IPSEC
0.642 #undef CONFIG_MLX5_EN_RXNFC
0.642 #undef CONFIG_MLX5_EN_SPECIAL_SQ
0.642 #undef CONFIG_MLX5_EN_TLS
0.642 #undef CONFIG_MLX5_ESWITCH
0.642 #undef CONFIG_MLX5_FPGA
0.642 #undef CONFIG_MLX5_FPGA_IPSEC
0.642 #undef CONFIG_MLX5_FPGA_TLS
0.642 #undef CONFIG_MLX5_INFINIBAND
0.642 #undef CONFIG_MLX5_IPSEC
0.642 #undef CONFIG_MLX5_MACSEC
0.642 #undef CONFIG_MLX5_MPFS
0.642 #undef CONFIG_MLX5_SF
0.642 #undef CONFIG_MLX5_SF_CFG
0.642 #undef CONFIG_MLX5_SF_MANAGER
0.642 #undef CONFIG_MLX5_SF_SFC
0.642 #undef CONFIG_MLX5_SW_STEERING
0.642 #undef CONFIG_MLX5_TC_CT
0.642 #undef CONFIG_MLX5_TC_SAMPLE
0.642 #undef CONFIG_MLX5_TLS
0.642 #undef CONFIG_MLX5_VDPA_NET_DUMMY
0.642 #undef CONFIG_MLXDEVM
0.642 #undef CONFIG_MLXFW
0.642 #undef CONFIG_NVME_APPLE
0.642 #undef CONFIG_NVME_COMMON
0.642 #undef CONFIG_NVME_CORE
0.642 #undef CONFIG_NVME_FABRICS
0.642 #undef CONFIG_NVME_FC
0.642 #undef CONFIG_NVME_HOST_AUTH
0.642 #undef CONFIG_NVME_HOST_DUMMY
0.642 #undef CONFIG_NVME_HOST_WITHOUT_FC
0.642 #undef CONFIG_NVME_MULTIPATH
0.642 #undef CONFIG_NVME_POLL
0.642 #undef CONFIG_NVME_RDMA
0.642 #undef CONFIG_NVME_TARGET
0.642 #undef CONFIG_NVME_TARGET_DUMMY
0.642 #undef CONFIG_NVME_TARGET_FC
0.642 #undef CONFIG_NVME_TARGET_FCLOOP
0.642 #undef CONFIG_NVME_TARGET_LOOP
0.642 #undef CONFIG_NVME_TARGET_RDMA
0.642 #undef CONFIG_NVME_TARGET_TCP
0.642 #undef CONFIG_NVME_TCP
0.642 #undef CONFIG_RDMA_RXE
0.642 #undef CONFIG_RDMA_RXE_DUMMY
0.642 #undef CONFIG_SCSI_ISCSI_ATTRS
0.642 #undef CONFIG_SCSI_SRP_ATTRS
0.642 #undef CONFIG_SUNRPC_XPRT_RDMA
0.642 #undef CONFIG_SUNRPC_XPRT_RDMA_DUMMY
0.642 #define CONFIG_BACKPORT_LRO 1
0.642 #define CONFIG_DEBUG_INFO 1
0.642 #define CONFIG_ENABLE_BASECODE_EXTRAS 1
0.642 #define CONFIG_ENABLE_VFIO 1
0.642 #define CONFIG_ENABLE_XDP 1
0.642 #define CONFIG_FWCTL 1
0.642 #define CONFIG_FWCTL_MLX5 1
0.642 #define CONFIG_INFINIBAND 1
0.642 #define CONFIG_INFINIBAND_ADDR_TRANS 1
0.642 #define CONFIG_INFINIBAND_ADDR_TRANS_CONFIGFS 1
0.642 #define CONFIG_INFINIBAND_IPOIB 1
0.642 #define CONFIG_INFINIBAND_IPOIB_CM 1
0.642 #define CONFIG_INFINIBAND_IPOIB_DEBUG 1
0.642 #define CONFIG_INFINIBAND_ISER 1
0.642 #define CONFIG_SCSI_ISCSI_ATTRS 1
0.642 #define CONFIG_ISCSI_TCP 1
0.642 #define CONFIG_INFINIBAND_ON_DEMAND_PAGING 1
0.642 #define CONFIG_INFINIBAND_SRP 1
0.642 #define CONFIG_INFINIBAND_USER_ACCESS 1
0.642 #define CONFIG_INFINIBAND_USER_ACCESS_UCM 1
0.642 #define CONFIG_INFINIBAND_USER_MAD 1
0.642 #define CONFIG_INFINIBAND_USER_MEM 1
0.642 #define CONFIG_MLX5_ACCEL 1
0.642 #define CONFIG_MLX5_BRIDGE 1
0.642 #define CONFIG_MLX5_CLS_ACT 1
0.642 #define CONFIG_MLX5_CORE 1
0.642 #define CONFIG_MLX5_CORE_EN 1
0.642 #define CONFIG_MLX5_CORE_EN_DCB 1
0.642 #define CONFIG_MLX5_CORE_IPOIB 1
0.642 #define CONFIG_MLX5_DEBUG 1
0.642 #define CONFIG_MLX5_EN_ARFS 1
0.642 #define CONFIG_MLX5_EN_RXNFC 1
0.642 #define CONFIG_MLX5_EN_SPECIAL_SQ 1
0.642 #define CONFIG_MLX5_ESWITCH 1
0.642 #define CONFIG_MLX5_INFINIBAND 1
0.642 #define CONFIG_MLX5_MPFS 1
0.642 #define CONFIG_MLX5_SF 1
0.642 #define CONFIG_MLX5_SF_MANAGER 1
0.642 #define CONFIG_MLX5_SW_STEERING 1
0.642 #define CONFIG_MLX5_TC_SAMPLE 1
0.642 #define CONFIG_MLXDEVM 1
0.642 #define CONFIG_SCSI_ISCSI_ATTRS 1
0.642 #define CONFIG_SCSI_SRP_ATTRS 1
0.642 #endif
0.687 checking build system type... x86_64-pc-linux-gnu
0.711 checking host system type... x86_64-pc-linux-gnu
0.711 checking target system type... x86_64-pc-linux-gnu
0.711 checking for a BSD-compatible install... /toolchain/bin/install -c
0.714 checking whether build environment is sane... yes
0.719 checking for a thread-safe mkdir -p... /toolchain/bin/mkdir -p
0.720 checking for gawk... gawk
0.720 checking whether make sets $(MAKE)... yes
0.725 checking whether make supports nested variables... yes
0.729 checking for gcc... gcc
0.740 checking whether the C compiler works... yes
0.758 checking for C compiler default output file name... a.out
0.758 checking for suffix of executables...
0.777 checking whether we are cross compiling... no
0.797 checking for suffix of object files... o
0.810 checking whether we are using the GNU C compiler... yes
0.823 checking whether gcc accepts -g... yes
0.834 checking for gcc option to accept ISO C89... none needed
0.854 checking whether gcc understands -c and -o together... yes
0.874 checking for style of include used by make... GNU
0.876 checking dependency style of gcc... none
0.876 checking dependency style of gcc... none
0.877 checking for ar... ar
0.877 checking how to run the C preprocessor... gcc -E
0.903 checking for grep that handles long lines and -e... /toolchain/bin/grep
0.904 checking for egrep... /toolchain/bin/grep -E
0.905 checking for ANSI C header files... yes
0.954 checking for sys/types.h... yes
0.968 checking for sys/stat.h... yes
0.981 checking for stdlib.h... yes
0.995 checking for string.h... yes
1.008 checking for memory.h... yes
1.021 checking for strings.h... yes
1.034 checking for inttypes.h... yes
1.047 checking for stdint.h... yes
1.062 checking for unistd.h... yes
1.075 checking for ranlib... ranlib
1.075 checking for ld... ld
1.075 checking for objdump... objdump
1.075 checking for strip... strip
1.075 checking size of unsigned long long... 8
1.101 ---> size SIZEOF
1.101 ---> size SIZEOF 8
1.104 checking for Linux sources... /src
1.105 checking for /src... yes
1.106 checking for Linux objects dir... /src
1.106 checking for /boot/kernel.h... no
1.106 checking for /var/adm/running-kernel.h... no
1.108 checking for /src/.config... yes
1.109 checking for /src/include/linux/kconfig.h... yes
1.111 checking for build ARCH... ARCH=x86_64, SRCARCH=x86
1.112 checking for cross compilation... no
1.112 checking if Linux was built with CONFIG_XEN... yes
1.641 checking get value of CONFIG_XEN_INTERFACE_VERSION... XEN_INTERFACE_VERSION in not defined in autoconf.h
1.641 checking that modules can be built at all... yes
2.195 6.6.47-talos
2.195 checking for MLNX release... 6.6.47_talos_
2.196 checking that RedHat kernel... no
2.687 checking if Linux was built with CONFIG_SUSE_KERNEL... no
3.176 checking name of module symbol version file... Module.symvers
3.177 checking if Linux was built with CONFIG_MODULES... yes
3.703 checking if Linux was built with CONFIG_MODVERSIONS... yes
4.231 checking if Linux was built with CONFIG_KALLSYMS... yes
4.754 checking if dpll_pin_ops.lock_status_get has status_error... ./configure: line 5849: /bin/mkdir: No such file or directory
4.755 checking if struct dpll_pin_ops exists... checking if struct dpll_pin_ops has ffo_get... checking if dpll.h has dpll_netdev_pin_set... checking if netdevice.h has netdev_dpll_pin_set... checking if __free anotation for kvfree could be used... checking if kvfree prototype is in slab.h... checking if have hmm_pfn_to_map_order... checking if vm_flags_clear exists... checking if hmm_range has hmm_pfns... checking if hmm_range_fault has one param... checking if rdma/ib_umem.h ib_umem_dmabuf_get_pinned defined... checking if has is_tcf_police... checking if udp_tunnel.h has enum UDP_TUNNEL_NIC_INFO_STATIC_IANA_VXLAN... checking if udp_tunnel.h has struct udp_tunnel_nic_info... checking if linux/netdevice.h has netdev_hold... checking if linux/netdevice.h has unregister_netdevice_notifier_net... checking if linux/netdevice.h has register_netdevice_notifier_dev_net... checking if linux/netdevice.h has dev_xdp_prog_id... checking if linux/netdevice.h has netdev_put... checking if struct netdev_net_notifier exists... checking if linux/netdevice.h has net_prefetch... checking if linux/mm.h has is_cow_mapping... checking if linux/mm.h has get_user_pages_longterm... checking if get_user_pages has 4 params... checking if get_user_pages has 5 params... checking if get_user_pages has 7 params... checking if map_lock has mmap_read_lock... checking if mm has get_user_pages_remote with 7 parameters and parameter 2 is integer... checking if mm has get_user_pages_remote with 8 parameters... checking if mm has get_user_pages_remote with 8 parameters with locked... checking if kernel.h has int_pow... checking if prandom.h has get_random_u32_inclusive... no
5.525 no
5.530 no
5.532 no
5.596 yes
5.597 ./configure: line 10691: CONFDEFS_H_DIR/confdefs.h.32: No such file or directory
5.917 yes
5.918 ./configure: line 6909: CONFDEFS_H_DIR/confdefs.h.7: No such file or directory
5.941 no
6.026 yes
6.026 ./configure: line 9327: CONFDEFS_H_DIR/confdefs.h.23: No such file or directory
6.036 no
6.049 no
6.062 no
6.063 no
6.077 no
6.093 no
6.094 yes
6.094 ./configure: line 7513: CONFDEFS_H_DIR/confdefs.h.11: No such file or directory
6.101 yes
6.101 ./configure: line 10085: CONFDEFS_H_DIR/confdefs.h.28: No such file or directory
6.109 yes
6.110 ./configure: line 7361: CONFDEFS_H_DIR/confdefs.h.10: No such file or directory
6.116 yes
6.116 ./configure: line 7209: CONFDEFS_H_DIR/confdefs.h.9: No such file or directory
6.121 yes
6.121 ./configure: line 7059: CONFDEFS_H_DIR/confdefs.h.8: No such file or directory
6.127 yes
6.127 ./configure: line 9631: CONFDEFS_H_DIR/confdefs.h.25: No such file or directory
6.279 no
6.285 yes
6.285 ./configure: line 9023: CONFDEFS_H_DIR/confdefs.h.21: No such file or directory
6.299 yes
6.299 yes
6.299 ./configure: line 9175: ./configure: line 8421: CONFDEFS_H_DIR/confdefs.h.22: No such file or directoryCONFDEFS_H_DIR/confdefs.h.17: No such file or directory
6.299
6.301 yes
6.301 ./configure: line 7813: CONFDEFS_H_DIR/confdefs.h.13: No such file or directory
6.326 yes
6.327 ./configure: line 8571: CONFDEFS_H_DIR/confdefs.h.18: No such file or directory
6.327 yes
6.327 ./configure: line 8721: CONFDEFS_H_DIR/confdefs.h.19: No such file or directory
6.329 yes
6.329 ./configure: line 8871: CONFDEFS_H_DIR/confdefs.h.20: No such file or directory
6.353 yes
6.354 ./configure: line 7665: CONFDEFS_H_DIR/confdefs.h.12: No such file or directory
6.354 yes
6.354 ./configure: line 8271: CONFDEFS_H_DIR/confdefs.h.16: No such file or directory
6.460 yes
6.461 ./configure: line 7969: CONFDEFS_H_DIR/confdefs.h.14: No such file or directory
6.468 yes
6.468 ./configure: line 8121: CONFDEFS_H_DIR/confdefs.h.15: No such file or directory
6.469 checking if random.h has get_random_u8... checking if struct net_device_ops has ndo_get_devlink_port... checking if devlink_fmsg_u8_pair_put returns int... checking if struct devlink_port_ops had port_fn_ipsec_crypto_get... checking if struct devlink_port_ops had port_fn_ipsec_packet_get... checking if kernel supports v6.7 devlink instances relationships exposure... checking if struct net_device has devlink_port member... checking if struct net_device has xdp_metadata_ops member... checking if kernel supports queue and napi association... checking if devlink.h devl_rate_leaf_create get 3 param... checking if devlink has devlink_info_version_fixed_put... checking if devlink.h devlink_port_type_eth_set get 1 param... checking if devlink.h has devl_param_driverinit_value_get... checking if devlink.h has devl_port_health_reporter_create... checking if devlink.h has devl_health_reporter_create... checking if devlink.h has devlink_info_driver_name_put... checking if devlink.h has devlink_set_features... checking if devlink.h has devlink_to_dev... checking if devlink.h devl_port_register defined... checking if devlink.h devl_trap_groups_register defined... checking if devlink.h devlink_param_register defined... checking if devlink.h has devlink_register get 1 params... checking if devlink.h has devl_register... checking if devlink.h has devl_resource_register... checking if devlink.h has devl_resources_unregister... checking if devlink.h has devlink_resources_unregister 2 params... checking if devlink.h has devlink_resources_unregister 1 params... checking if devlink.h has devlink_alloc get 3 params... checking if devlink.h has devlink_port_attrs_pci_sf_set get 4 params... checking if devlink.h has devlink_port_attrs_pci_sf_set get 5 params... checking if devlink.h devlink_port_attrs_pci_vf_set get 3 params... checking if devlink has devlink_port_attrs_pci_vf_set has 5 params... checking if devlink has devlink_port_attrs_pci_vf_set has 5 params and controller num... ./configure: line 10995: CONFDEFS_H_DIR/confdefs.h.34: No such file or directory
7.518 yes
7.544 yes
7.547 ./configure: line 10843: CONFDEFS_H_DIR/confdefs.h.33: No such file or directory
8.134 yes
8.136 ./configure: line 11459: CONFDEFS_H_DIR/confdefs.h.37: No such file or directory
8.144 no
8.172 no
8.178 no
8.182 no
8.182 yes
8.183 ./configure: line 11303: CONFDEFS_H_DIR/confdefs.h.36: No such file or directory
8.188 no
8.191 no
8.198 no
8.207 yes
8.207 ./configure: line 13155: CONFDEFS_H_DIR/confdefs.h.48: No such file or directory
8.209 yes
8.209 no
8.209 ./configure: line 14219: CONFDEFS_H_DIR/confdefs.h.55: No such file or directory
8.213 yes
8.213 ./configure: line 14675: CONFDEFS_H_DIR/confdefs.h.58: No such file or directory
8.216 yes
8.216 ./configure: line 12853: CONFDEFS_H_DIR/confdefs.h.46: No such file or directory
8.221 yes
8.221 ./configure: line 14371: CONFDEFS_H_DIR/confdefs.h.56: No such file or directory
8.227 yes
8.228 ./configure: line 13915: CONFDEFS_H_DIR/confdefs.h.53: No such file or directory
8.230 no
8.234 yes
8.234 ./configure: line 13003: CONFDEFS_H_DIR/confdefs.h.47: No such file or directory
8.238 yes
8.239 ./configure: line 12549: CONFDEFS_H_DIR/confdefs.h.44: No such file or directory
8.245 yes
8.245 ./configure: line 14979: CONFDEFS_H_DIR/confdefs.h.60: No such file or directory
8.247 yes
8.247 ./configure: line 13611: CONFDEFS_H_DIR/confdefs.h.51: No such file or directory
8.248 yes
8.248 ./configure: line 14523: CONFDEFS_H_DIR/confdefs.h.57: No such file or directory
8.257 yes
8.257 ./configure: line 15131: CONFDEFS_H_DIR/confdefs.h.61: No such file or directory
8.273 yes
8.273 ./configure: line 12399: CONFDEFS_H_DIR/confdefs.h.43: No such file or directory
8.277 yes
8.277 ./configure: line 11615: CONFDEFS_H_DIR/confdefs.h.38: No such file or directory
8.285 yes
8.285 ./configure: line 13763: CONFDEFS_H_DIR/confdefs.h.52: No such file or directory
8.286 yes
8.286 ./configure: line 12087: CONFDEFS_H_DIR/confdefs.h.41: No such file or directory
8.286 yes
8.287 ./configure: line 15435: CONFDEFS_H_DIR/confdefs.h.63: No such file or directory
8.288 yes
8.288 ./configure: line 11931: CONFDEFS_H_DIR/confdefs.h.40: No such file or directory
8.288 yes
8.288 ./configure: line 12701: CONFDEFS_H_DIR/confdefs.h.45: No such file or directory
8.308 no
8.309 checking if devlink.h devlink_port_attrs_pci_pf_set get 2 params... checking if devlink.h has devlink_fmsg_binary_pair_nest_start... checking if devlink has devlink_flash_update_status_notify... checking if devlink has devlink_flash_update_end_notify... checking if devlink has devlink_port_type_eth_set... checking if devlink has devlink_health_reporter_state_update... checking if devlink_health_reporter_ops.recover has extack parameter... checking if struct devlink_param set function pointer has extack parameter... checking if devlink has devlink_param_driverinit_value_get... checking if devlink enum has DEVLINK_PARAM_GENERIC_ID_IO_EQ_SIZE... checking if devlink enum has HAVE_DEVLINK_PARAM_GENERIC_ID_ENABLE_ETH... checking if devlink struct devlink_port_new_attrs exist... checking if devlink_port_attrs_set has 7 parameters... checking if devlink_port_attrs_set has 5 parameters... checking if devlink_port_attrs_set has 2 parameters... checking if devlink enum has DEVLINK_PARAM_GENERIC_ID_ENABLE_ROCE... checking if devlink enum has DEVLINK_PARAM_GENERIC_ID_ENABLE_REMOTE_DEV_RESET... checking if devlink enum devlink_port_fn_state exist... checking if devlink enum devlink_port_fn_opstate exist... checking if devlink enum has DEVLINK_PORT_FLAVOUR_VIRTUAL... checking if devlink enum has DEVLINK_PORT_FLAVOUR_PCI_SF... checking if devlink has devlink_reload_disable... checking if devlink has devlink_reload_enable... checking if devlink has devlink_net... checking if struct devlink_ops has reload has 2 params... checking if struct devlink_ops has reload_up/down... checking if devlink_ops.port_function_hw_addr_get has 4 params... checking if devlink_ops.port_function_state_get has 4 params... checking if struct devlink_ops has port_function_state_get/set... checking if devlink_ops.reload_down has 3 params... checking if devlink_ops.reload_down has 5 params... checking if struct devlink_port_ops exists... checking if struct devlink_ops has info_get... yes
9.213 ./configure: line 19065: CONFDEFS_H_DIR/confdefs.h.87: No such file or directory
9.214 yes
9.214 ./configure: line 18915: CONFDEFS_H_DIR/confdefs.h.86: No such file or directory
9.222 yes
9.222 ./configure: line 18765: CONFDEFS_H_DIR/confdefs.h.85: No such file or directory
9.235 yes
9.235 ./configure: line 18615: CONFDEFS_H_DIR/confdefs.h.84: No such file or directory
9.863 no
9.874 no
9.891 no
9.948 no
9.956 no
9.956 no
9.962 no
9.980 no
9.981 no
9.982 yes
9.982 ./configure: line 17415: CONFDEFS_H_DIR/confdefs.h.76: No such file or directory
9.984 no
9.984 no
9.988 yes
9.989 ./configure: line 19515: CONFDEFS_H_DIR/confdefs.h.90: No such file or directory
9.995 no
9.998 no
10.01 yes
10.01 ./configure: line 16191: CONFDEFS_H_DIR/confdefs.h.68: No such file or directory
10.01 yes
10.01 ./configure: line 15887: CONFDEFS_H_DIR/confdefs.h.66: No such file or directory
10.01 yes
10.01 ./configure: line 17565: CONFDEFS_H_DIR/confdefs.h.77: No such file or directory
10.01 yes
10.01 ./configure: line 16955: CONFDEFS_H_DIR/confdefs.h.73: No such file or directory
10.02 no
10.02 yes
10.02 ./configure: line 16341: CONFDEFS_H_DIR/confdefs.h.69: No such file or directory
10.02 yes
10.02 ./configure: line 16791: CONFDEFS_H_DIR/confdefs.h.72: No such file or directory
10.04 yes
10.04 ./configure: line 17715: CONFDEFS_H_DIR/confdefs.h.78: No such file or directory
10.04 yes
10.04 ./configure: line 18465: CONFDEFS_H_DIR/confdefs.h.83: No such file or directory
10.05 yes
10.05 ./configure: line 18315: CONFDEFS_H_DIR/confdefs.h.82: No such file or directory
10.05 yes
10.05 ./configure: line 19843: CONFDEFS_H_DIR/confdefs.h.92: No such file or directory
10.07 yes
10.07 ./configure: line 20689: CONFDEFS_H_DIR/confdefs.h.97: No such file or directory
10.08 yes
10.08 ./configure: line 18165: CONFDEFS_H_DIR/confdefs.h.81: No such file or directory
10.09 yes
10.09 ./configure: line 20843: CONFDEFS_H_DIR/confdefs.h.98: No such file or directory
10.09 checking if devlink struct devlink_trap exists... checking if devlink has DEVLINK_TRAP_GENERIC_ID_DMAC_FILTER... checking if devlink_ops.trap_action_set has 4 args... checking if devlink_trap_report has 5 args... checking if devlink has DEVLINK_TRAP_GROUP_GENERIC with 2 args... checking if devlink has devlink_trap_groups_register... checking if devlink has devlink_port_health_reporter_create... checking if devlink has devlink_port_health_reporter_destroy... checking if devlink has devlink_health_reporter_create with 5 args... checking if devlink has devlink_health_reporter_create with 4 args... checking if devlink has devlink_health_reporter & devlink_fmsg... checking if devlink has devlink_fmsg_binary_put... checking if devlink has devlink_fmsg_binary_pair_put... checking if devlink has devlink_fmsg_binary_pair_put... checking if struct devlink_ops.eswitch_mode_set has extack... checking if struct devlink_ops has port_function_roce/mig_get/set... checking if struct devlink_ops has port_function_hw_addr_get/set... checking if struct devlink_ops has rate functions... checking if struct devlink_ops defines eswitch_encap_mode_set/get with enum arg... checking if struct devlink_ops has flash_update... checking if struct devlink_ops flash_update get 3 params... checking if devlink has devlink_port_attrs_pci_pf_set has 4 params... checking if devlink has devlink_port_attrs_pci_pf_set has 4 params and controller num... checking if devlink has devlink_port_attrs_pci_pf_set has 2 params... checking if devlink_flash_update_params has struct firmware fw... checking if exists netif_carrier_event... checking if netif_device_present get const... checking if struct devlink_port has attrs.switch_port... checking if struct devlink_port has attrs.switch_id... checking if struct net_device has devlink_port... checking if struct net_device has lower_level... checking if netdev_lag_hash has NETDEV_LAG_HASH_VLAN_SRCMAC... checking if ethtool_link_ksettings has lanes... no
11.85 no
11.85 no
11.86 no
11.87 yes
11.87 ./configure: line 23041: CONFDEFS_H_DIR/confdefs.h.112: No such file or directory
11.87 no
11.87 yes
11.87 ./configure: line 21923: CONFDEFS_H_DIR/confdefs.h.105: No such file or directory
11.88 yes
11.88 ./configure: line 24961: CONFDEFS_H_DIR/confdefs.h.124: No such file or directory
11.89 yes
11.89 ./configure: line 22543: CONFDEFS_H_DIR/confdefs.h.109: No such file or directory
11.89 yes
11.89 ./configure: line 21149: CONFDEFS_H_DIR/confdefs.h.100: No such file or directory
11.90 yes
11.90 ./configure: line 21619: CONFDEFS_H_DIR/confdefs.h.103: No such file or directory
11.90 no
11.90 yes
11.90 ./configure: line 21299: CONFDEFS_H_DIR/confdefs.h.101: No such file or directory
11.91 yes
11.91 ./configure: line 22873: CONFDEFS_H_DIR/confdefs.h.111: No such file or directory
11.91 yes
11.91 ./configure: line 22717: CONFDEFS_H_DIR/confdefs.h.110: No such file or directory
11.92 yes
11.92 ./configure: line 22079: CONFDEFS_H_DIR/confdefs.h.106: No such file or directory
11.94 yes
11.94 ./configure: line 23373: CONFDEFS_H_DIR/confdefs.h.114: No such file or directory
11.94 no
11.94 yes
11.94 ./configure: line 20999: CONFDEFS_H_DIR/confdefs.h.99: No such file or directory
11.94 yes
11.94 ./configure: line 23849: CONFDEFS_H_DIR/confdefs.h.117: No such file or directory
11.94 yes
11.94 ./configure: line 26043: CONFDEFS_H_DIR/confdefs.h.131: No such file or directory
11.95 yes
11.95 ./configure: line 25579: CONFDEFS_H_DIR/confdefs.h.128: No such file or directory
11.95 yes
11.95 ./configure: line 24185: CONFDEFS_H_DIR/confdefs.h.119: No such file or directory
11.95 yes
11.95 yes
11.95 ./configure: line 25113: CONFDEFS_H_DIR/confdefs.h.125: No such file or directory
11.95 ./configure: line 24657: CONFDEFS_H_DIR/confdefs.h.122: No such file or directory
11.95 yes
11.95 ./configure: line 24029: CONFDEFS_H_DIR/confdefs.h.118: No such file or directory
11.95 no
11.95 yes
11.95 ./configure: line 24357: CONFDEFS_H_DIR/confdefs.h.120: No such file or directory
11.95 yes
11.95 ./configure: line 25891: CONFDEFS_H_DIR/confdefs.h.130: No such file or directory
11.97 yes
11.97 ./configure: line 21773: CONFDEFS_H_DIR/confdefs.h.104: No such file or directory
11.98 yes
11.98 ./configure: line 25267: CONFDEFS_H_DIR/confdefs.h.126: No such file or directory
11.98 yes
11.98 ./configure: line 25735: CONFDEFS_H_DIR/confdefs.h.129: No such file or directory
12.04 yes
12.04 ./configure: line 21469: CONFDEFS_H_DIR/confdefs.h.102: No such file or directory
12.04 checking if ethtool.h kernel_ethtool_ringparam has tcp_data_split member... checking if ethtool.h has struct kernel_ethtool_ringparam... checking if struct ethtool_ops has supported_coalesce_params... checking if struct ethtool_ops has get_module_eeprom_by_page... checking if net/tls.h has tls_is_skb_tx_device_offloaded... checking if net/tls.h has struct tls_offload_resync_async... checking if ktls related structs exists... checking if struct tlsdev_ops has tls_dev_resync... checking if linux/skbuff.h skb_frag_fill_page_desc exists... checking if linux/skbuff.h napi_build_skb exists... checking if skb_frag_off_add exists... checking if skb_frag_off_set exists... checking if napi_reschedule exists... checking if struct net_device has devlink_port as member... checking if struct devlink_port_osp has del_port as cb... checking if struct net_device_ops has ndo_xsk_wakeup... checking if enum tc_htb_command exists... checking if struct tc_htb_qopt_offload has prio... checking if struct tc_htb_qopt_offload has quantum... checking if struct tc_cls_flower_offload exists... checking if struct tc_block_offload exists... checking if struct flow_block_offload exists... checking if struct flow_block_offload hash unlocked_driver_cb... checking if NL_SET_ERR_MSG_WEAK_MOD exists... checking if tc_cls_common_offload has extack... checking if struct tc_block_offload has extack... checking if struct ptp_clock_info has gettimex64... checking if struct ptp_clock_info has getmaxphase... checking if struct ptp_clock_info has adjfreq... checking if struct ptp_clock_info has adjphase... checking if adjust_by_scaled_ppm exists... checking if pci_dev has link_active_reporting... checking if pci.h has pci_iov_vf_id... yes
13.68 ./configure: line 31136: CONFDEFS_H_DIR/confdefs.h.164: No such file or directory
13.69 yes
13.69 ./configure: line 27739: CONFDEFS_H_DIR/confdefs.h.142: No such file or directory
13.72 yes
13.72 ./configure: line 27891: CONFDEFS_H_DIR/confdefs.h.143: No such file or directory
13.73 yes
13.73 ./configure: line 30362: CONFDEFS_H_DIR/confdefs.h.159: No such file or directory
13.74 yes
13.74 ./configure: line 30982: CONFDEFS_H_DIR/confdefs.h.163: No such file or directory
13.75 yes
13.75 ./configure: line 27587: CONFDEFS_H_DIR/confdefs.h.141: No such file or directory
13.75 yes
13.75 ./configure: line 28043: CONFDEFS_H_DIR/confdefs.h.144: No such file or directory
13.76 yes
13.76 ./configure: line 26355: CONFDEFS_H_DIR/confdefs.h.133: No such file or directory
13.76 yes
13.76 ./configure: line 29898: CONFDEFS_H_DIR/confdefs.h.156: No such file or directory
13.77 yes
13.77 ./configure: line 30830: CONFDEFS_H_DIR/confdefs.h.162: No such file or directory
13.77 no
13.78 no
13.79 yes
13.79 ./configure: line 26199: CONFDEFS_H_DIR/confdefs.h.132: No such file or directory
13.79 yes
13.79 ./configure: line 26505: CONFDEFS_H_DIR/confdefs.h.134: No such file or directory
13.80 no
13.80 no
13.80 no
13.83 yes
13.83 ./configure: line 30518: CONFDEFS_H_DIR/confdefs.h.160: No such file or directory
13.84 yes
13.84 ./configure: line 29132: CONFDEFS_H_DIR/confdefs.h.151: No such file or directory
13.84 yes
13.84 yes
13.84 ./configure: line 28820: CONFDEFS_H_DIR/confdefs.h.149: No such file or directory
13.84 ./configure: line 28976: CONFDEFS_H_DIR/confdefs.h.150: No such file or directory
13.85 yes
13.85 ./configure: line 26817: CONFDEFS_H_DIR/confdefs.h.136: No such file or directory
13.85 yes
13.85 ./configure: line 28511: CONFDEFS_H_DIR/confdefs.h.147: No such file or directory
13.85 yes
13.85 ./configure: line 28668: CONFDEFS_H_DIR/confdefs.h.148: No such file or directory
13.86 yes
13.86 ./configure: line 28355: CONFDEFS_H_DIR/confdefs.h.146: No such file or directory
13.87 yes
13.87 ./configure: line 29590: CONFDEFS_H_DIR/confdefs.h.154: No such file or directory
13.88 yes
13.88 ./configure: line 28199: CONFDEFS_H_DIR/confdefs.h.145: No such file or directory
13.89 yes
13.89 ./configure: line 29744: CONFDEFS_H_DIR/confdefs.h.155: No such file or directory
13.94 yes
13.94 ./configure: line 26661: CONFDEFS_H_DIR/confdefs.h.135: No such file or directory
14.03 yes
14.03 ./configure: line 27435: CONFDEFS_H_DIR/confdefs.h.140: No such file or directory
14.03 yes
14.03 ./configure: line 27121: CONFDEFS_H_DIR/confdefs.h.138: No such file or directory
14.07 yes
14.07 ./configure: line 27279: CONFDEFS_H_DIR/confdefs.h.139: No such file or directory
14.09 yes
14.09 ./configure: line 26969: CONFDEFS_H_DIR/confdefs.h.137: No such file or directory
14.09 checking if pci.h has pci_iov_get_pf_drvdata... checking if mm.h has want_init_on_alloc... checking if struct page has dma_addr array member... checking if skbuff.h has skb_frag_off... checking if skbuff.h has dev_page_is_reusable... checking if net/pkt_cls.h has tc_skb_ext_alloc... checking if netdevice.h dev_change_flags has 3 parameters... checking if user_access_begin has 2 parameters... checking if user_access_begin has 3 parameters... checking if uaccess.h access_ok has 3 parameters... checking if uaccess.h access_ok has check_zeroed_user... checking if mm.h put_user_pages_dirty_lock has 3 parameters... checking if mm.h put_user_pages_dirty_lock has 2 parameters... checking if flow_dissector.h has struct flow_dissector_mpls_lse... checking if enum switchdev_attr_id has SWITCHDEV_ATTR_ID_BRIDGE_VLAN_PROTOCOL... checking if switchdev.h has struct switchdev_ops... checking if struct switchdev_obj_port_vlan has vid... checking if struct switchdev_brport_flags exist... checking if switchdev.h has switchdev_port_same_parent_id... checking if struct sk_buff has xmit_more... checking if xfrm_dev_offload has flags... checking if xfrm_dev_offload has real_dev as member... checking if xfrm_state_offload has dir as member... checking if xfrm_dev_offload has dir as member... checking if xfrm_dev_offload has type as member... checking if xfrm_state_offload has real_dev as member... checking if secpath_set returns struct sec_path *... checking if eth_get_headlen has 3 params... checking if eth_get_headlen has 2 params... checking if if_vlan.h has vlan_get_encap_level... checking if struct vlan_ethhdr has addrs member... checking if ndo_select_queue has accel_priv... checking if ndo_select_queue has a second net_device parameter... yes
15.10 ./configure: line 33438: CONFDEFS_H_DIR/confdefs.h.179: No such file or directory
15.17 no
15.27 no
15.29 no
15.33 yes
15.33 ./configure: line 32984: CONFDEFS_H_DIR/confdefs.h.176: No such file or directory
15.35 yes
15.35 ./configure: line 32516: CONFDEFS_H_DIR/confdefs.h.173: No such file or directory
15.45 no
15.50 no
15.52 yes
15.52 ./configure: line 31592: CONFDEFS_H_DIR/confdefs.h.167: No such file or directory
15.54 yes
15.54 ./configure: line 31440: CONFDEFS_H_DIR/confdefs.h.166: No such file or directory
15.56 yes
15.56 ./configure: line 31288: CONFDEFS_H_DIR/confdefs.h.165: No such file or directory
15.60 no
15.69 yes
15.69 ./configure: line 31896: CONFDEFS_H_DIR/confdefs.h.169: No such file or directory
15.73 no
15.73 yes
15.73 ./configure: line 32048: CONFDEFS_H_DIR/confdefs.h.170: No such file or directory
15.76 yes
15.76 ./configure: line 36240: CONFDEFS_H_DIR/confdefs.h.197: No such file or directory
15.78 yes
15.78 ./configure: line 36072: CONFDEFS_H_DIR/confdefs.h.196: No such file or directory
15.78 no
15.79 no
15.81 yes
15.81 ./configure: line 32356: CONFDEFS_H_DIR/confdefs.h.172: No such file or directory
15.84 yes
15.84 ./configure: line 35612: CONFDEFS_H_DIR/confdefs.h.193: No such file or directory
15.84 no
15.84 yes
15.84 ./configure: line 33590: CONFDEFS_H_DIR/confdefs.h.180: No such file or directory
15.84 no
15.88 no
15.88 yes
15.88 ./configure: line 34996: CONFDEFS_H_DIR/confdefs.h.189: No such file or directory
15.88 no
15.90 yes
15.90 ./configure: line 34057: CONFDEFS_H_DIR/confdefs.h.183: No such file or directory
15.92 yes
15.92 ./configure: line 35152: CONFDEFS_H_DIR/confdefs.h.190: No such file or directory
15.93 yes
15.93 ./configure: line 33904: CONFDEFS_H_DIR/confdefs.h.182: No such file or directory
15.93 yes
15.93 ./configure: line 34528: CONFDEFS_H_DIR/confdefs.h.186: No such file or directory
15.94 yes
15.94 ./configure: line 35460: CONFDEFS_H_DIR/confdefs.h.192: No such file or directory
15.95 yes
15.95 ./configure: line 34684: CONFDEFS_H_DIR/confdefs.h.187: No such file or directory
15.95 checking if include/linux/cleanup.h exists... checking if include/linux/container_of.h exists... checking if include/linux/panic.h exists... checking if include/linux/bits.h exists... checking if include/net/devlink.h devlink_alloc_ns defined... checking if struct flow_dissector_key_vlan has vlan_eth_type... checking if FLOW_ACTION_CONTINUE exists... checking if FLOW_ACTION_JUMP and PIPE exists... checking if FLOW_ACTION_PRIORITY exists... checking if FLOW_ACTION_VLAN_PUSH_ETH exists... checking if HAVE_FLOW_OFFLOAD_ACTION exists... checking if flow_offload_has_one_action exists... checking if pkt_cls.h has tc_setup_flow_action... checking if pkt_cls.h has tc_setup_offload_action... checking if pkt_cls.h has tc_setup_offload_action get 3 param... checking if pkt_cls.h has tc_setup_flow_action with rtnl_held... checking if pkt_cls.h has __tc_indr_block_cb_register... checking if pkt_cls.h has TC_CLSMATCHALL_STATS... checking if have __flow_indr_block_cb_register... checking if have flow_cls_offload_flow_rule... checking if have flow_block_cb_setup_simple... checking if have flow_block_cb_alloc... checking if have flow_setup_cb_t... checking if net/ipv6_stubs.h exists... checking if net/rps.h exists... checking if struct net_device_ops has ndo_eth_ioctl... checking if struct net_device_ops has ndo_get_port_parent_id... checking if netdevice.h has struct netdev_nested_priv... checking if dev_get_port_parent_id exists... checking if dev_addr_mod exists... checking if netdev_get_xmit_slave exists... checking if net/lag.h exists... checking if net/lag.h net_lag_port_dev_txable exists... no
16.83 yes
16.83 ./configure: line 36706: CONFDEFS_H_DIR/confdefs.h.200: No such file or directory
16.84 yes
16.84 ./configure: line 37002: CONFDEFS_H_DIR/confdefs.h.202: No such file or directory
16.85 yes
16.85 ./configure: line 36854: CONFDEFS_H_DIR/confdefs.h.201: No such file or directory
16.85 yes
16.85 ./configure: line 37308: CONFDEFS_H_DIR/confdefs.h.204: No such file or directory
16.86 yes
16.86 ./configure: line 36558: CONFDEFS_H_DIR/confdefs.h.199: No such file or directory
17.42 yes
17.42 ./configure: line 37762: CONFDEFS_H_DIR/confdefs.h.207: No such file or directory
17.57 yes
17.57 ./configure: line 37612: CONFDEFS_H_DIR/confdefs.h.206: No such file or directory
17.58 yes
17.58 ./configure: line 40960: CONFDEFS_H_DIR/confdefs.h.228: No such file or directory
17.58 no
17.58 no
17.58 yes
17.58 ./configure: line 39432: CONFDEFS_H_DIR/confdefs.h.218: No such file or directory
17.59 yes
17.59 ./configure: line 39888: CONFDEFS_H_DIR/confdefs.h.221: No such file or directory
17.59 yes
17.59 ./configure: line 39584: CONFDEFS_H_DIR/confdefs.h.219: No such file or directory
17.59 yes
17.60 ./configure: line 38062: CONFDEFS_H_DIR/confdefs.h.209: No such file or directory
17.60 yes
17.60 ./configure: line 38216: CONFDEFS_H_DIR/confdefs.h.210: No such file or directory
17.60 yes
17.60 ./configure: line 37912: CONFDEFS_H_DIR/confdefs.h.208: No such file or directory
17.60 yes
17.60 ./configure: line 37458: CONFDEFS_H_DIR/confdefs.h.205: No such file or directory
17.60 yes
17.60 ./configure: line 38672: CONFDEFS_H_DIR/confdefs.h.213: No such file or directory
17.60 no
17.61 no
17.61 yes
17.61 ./configure: line 39736: CONFDEFS_H_DIR/confdefs.h.220: No such file or directory
17.62 yes
17.62 ./configure: line 40660: CONFDEFS_H_DIR/confdefs.h.226: No such file or directory
17.62 yes
17.62 ./configure: line 39128: CONFDEFS_H_DIR/confdefs.h.216: No such file or directory
17.62 yes
17.62 ./configure: line 40508: CONFDEFS_H_DIR/confdefs.h.225: No such file or directory
17.63 no
17.64 no
17.65 yes
17.65 ./configure: line 40036: CONFDEFS_H_DIR/confdefs.h.222: No such file or directory
17.67 yes
17.67 ./configure: line 37152: CONFDEFS_H_DIR/confdefs.h.203: No such file or directory
17.69 yes
17.69 ./configure: line 41110: CONFDEFS_H_DIR/confdefs.h.229: No such file or directory
17.70 yes
17.70 ./configure: line 40810: CONFDEFS_H_DIR/confdefs.h.227: No such file or directory
17.72 yes
17.72 ./configure: line 40340: CONFDEFS_H_DIR/confdefs.h.224: No such file or directory
17.81 yes
17.81 ./configure: line 41258: CONFDEFS_H_DIR/confdefs.h.230: No such file or directory
17.81 checking if ndo_get_ringparam get 4 parameters... checking if ndo_get_coalesce get 4 parameters... checking if struct ethtool_ops has get_pause_stats... checking if struct ethtool_ops has get_link_ext_state... checking if net/tls.h has tls_offload_rx_resync_async_request_start... checking if ethtool supports 50G-pre-lane link modes... checking if struct ethtool_ops has get/set_rxfh_context... checking if struct ethtool_ops has get/set_settings... checking if linux/ethtool_netlink.h exists... checking if pci.h has pci_msix_can_alloc_dyn... checking if cpu_rmap.h has irq_cpu_rmap_remove... checking if irq.h has irq_get_effective_affinity_mask... checking if pkt_cls.h enum enum tc_fl_command has TC_CLSFLOWER_STATS... checking if struct tc_cls_flower_offload has stats field... checking if linux/inetdevice.h has for_ifa define... checking if netdevice.h has netdev_port_same_parent_id... checking if netdev_features.h has NETIF_F_HW_TLS_RX... checking if tls_offload_context_tx has destruct_work as member... checking if ndo_add_vxlan_port have udp_tunnel_info... checking if ipv6_stub has ipv6_dst_lookup_flow... checking if ipv6_stub has ipv6_dst_lookup_flow in addrconf.h... checking if nla_policy has validation_type... checking if netlink.h has nla_strscpy... checking if netlink.h has nla_nest_start_noflag... checking if netlink.h has nlmsg_validate_deprecated ... checking if netlink.h has nlmsg_parse_deprecated ... checking if netlink.h has nla_parse_deprecated ... checking if struct genl_ops has member validate... checking if struct genl_family has member resv_start_op... checking if struct genl_family has member policy... checking if struct netlink_callback has member extack... checking if sysfs.h has sysfs_emit... checking if ethtool.h has struct ethtool_pause_stats... yes
18.81 ./configure: line 44102: CONFDEFS_H_DIR/confdefs.h.248: No such file or directory
19.05 yes
19.05 ./configure: line 43178: CONFDEFS_H_DIR/confdefs.h.242: No such file or directory
19.13 yes
19.13 ./configure: line 46422: CONFDEFS_H_DIR/confdefs.h.263: No such file or directory
19.15 yes
19.15 ./configure: line 43332: CONFDEFS_H_DIR/confdefs.h.243: No such file or directory
19.32 yes
19.32 ./configure: line 43022: CONFDEFS_H_DIR/confdefs.h.241: No such file or directory
19.43 no
19.47 yes
19.47 ./configure: line 45038: CONFDEFS_H_DIR/confdefs.h.254: No such file or directory
19.47 yes
19.47 ./configure: line 41582: CONFDEFS_H_DIR/confdefs.h.232: No such file or directory
19.48 yes
19.48 ./configure: line 42402: CONFDEFS_H_DIR/confdefs.h.237: No such file or directory
19.49 no
19.50 yes
19.50 ./configure: line 41754: CONFDEFS_H_DIR/confdefs.h.233: No such file or directory
19.50 yes
19.50 ./configure: line 45646: CONFDEFS_H_DIR/confdefs.h.258: No such file or directory
19.51 no
19.51 yes
19.51 ./configure: line 45494: CONFDEFS_H_DIR/confdefs.h.257: No such file or directory
19.51 yes
19.51 ./configure: line 45342: CONFDEFS_H_DIR/confdefs.h.256: No such file or directory
19.51 yes
19.51 ./configure: line 42560: CONFDEFS_H_DIR/confdefs.h.238: No such file or directory
19.51 yes
19.51 ./configure: line 44886: CONFDEFS_H_DIR/confdefs.h.253: No such file or directory
19.52 yes
19.52 ./configure: line 45958: CONFDEFS_H_DIR/confdefs.h.260: No such file or directory
19.52 yes
19.52 ./configure: line 41910: CONFDEFS_H_DIR/confdefs.h.234: No such file or directory
19.52 yes
19.53 ./configure: line 46270: CONFDEFS_H_DIR/confdefs.h.262: No such file or directory
19.53 yes
19.53 ./configure: line 45190: CONFDEFS_H_DIR/confdefs.h.255: No such file or directory
19.53 yes
19.53 ./configure: line 42066: CONFDEFS_H_DIR/confdefs.h.235: No such file or directory
19.54 no
19.55 yes
19.55 ./configure: line 46114: CONFDEFS_H_DIR/confdefs.h.261: No such file or directory
19.55 yes
19.55 ./configure: line 45802: CONFDEFS_H_DIR/confdefs.h.259: No such file or directory
19.55 no
19.57 yes
19.57 ./configure: line 42866: CONFDEFS_H_DIR/confdefs.h.240: No such file or directory
19.60 yes
19.60 ./configure: line 43950: CONFDEFS_H_DIR/confdefs.h.247: No such file or directory
19.61 no
19.72 yes
19.72 ./configure: line 44580: CONFDEFS_H_DIR/confdefs.h.251: No such file or directory
19.73 yes
19.73 ./configure: line 41410: CONFDEFS_H_DIR/confdefs.h.231: No such file or directory
19.76 yes
19.76 ./configure: line 42218: CONFDEFS_H_DIR/confdefs.h.236: No such file or directory
19.77 yes
19.77 ./configure: line 44256: CONFDEFS_H_DIR/confdefs.h.249: No such file or directory
19.77 checking if ethtool.h has struct ethtool_rmon_hist_range... checking if ethtool.h has get_link_ext_stats... checking if ethtool.h has ndo eth_phy_stats... checking if ethtool.h has ndo get_fec_stats... checking if skbuff.h has skb_set_redirected... checking if addrconf.h ipv6_dst_lookup takes net... checking if build_bug.h has static_assert... checking if register_fib_notifier has 4 params... checking if function fib_info_nh exists in file net/nexthop.h... checking if function fib6_info_nh_dev exists in file net/nexthop.h... checking if linux/kobject.h kobj_type has default_groups member... checking if linux/lockdep.h has lockdep_unregister_key... checking if linux/lockdep.h has lockdep_assert_held_exclusive... checking if linux/lockdep.h has lockdep_assert_held_write... checking if fib_nh has fib_nh_dev... checking if struct page has dma_addr... checking if struct mm_struct has member atomic_pinned_vm... checking if struct mm_struct has member pinned_vm... checking if route.h struct rtable has member rt_gw_family... checking if route.h struct rtable has member rt_uses_gateway... checking if Linux was built with symbol cancel_work exported... yes
19.78 checking if Linux was built with symbol unpin_user_pages_dirty_lock exported... yes
19.78 checking if Linux was built with symbol unpin_user_page_range_dirty_lock exported... yes
19.78 checking if Linux was built with symbol compat_ptr_ioctl exported... yes
19.78 checking if Linux was built with symbol flow_rule_match_cvlan exported... yes
19.78 checking if Linux was built with symbol devlink_params_publish exported... no
19.78 checking if Linux was built with symbol devlink_param_publish exported... no
19.79 checking if Linux was built with symbol split_page exported... yes
19.79 checking if Linux was built with symbol ip6_dst_hoplimit exported... yes
19.79 checking if Linux was built with symbol __ip_dev_find exported... yes
19.79 checking if Linux was built with symbol inet_confirm_addr exported... yes
19.79 checking if Linux was built with symbol dev_pm_qos_update_user_latency_tolerance exported... yes
19.79 checking if pci.h has pci_pool_zalloc... checking if struct net_device_ops has *ndo_bridge_setlink... checking if struct net_device_ops has *ndo_bridge_setlink... checking if struct net_device_ops has *ndo_get_vf_guid... checking if pci.h has pci_irq_get_node... checking if Linux was built with symbol fib_lookup exported... no
19.80 checking if idr.h has ida_free... checking if idr.h has ida_alloc_range... checking if idr.h has ida_alloc... checking if idr.h has ida_alloc_max... checking if xarray is defined... checking if xa_for_each_range is defined... checking if DEFINE_SEQ_ATTRIBUTE is defined... checking if scsi_cmd_to_rq is defind... yes
20.76 ./configure: line 47656: CONFDEFS_H_DIR/confdefs.h.271: No such file or directory
20.78 no
20.81 yes
20.81 ./configure: line 48716: CONFDEFS_H_DIR/confdefs.h.278: No such file or directory
20.84 yes
20.84 ./configure: line 48412: CONFDEFS_H_DIR/confdefs.h.276: No such file or directory
20.85 no
20.91 yes
20.91 ./configure: line 49028: CONFDEFS_H_DIR/confdefs.h.280: No such file or directory
20.92 yes
20.92 ./configure: line 49184: CONFDEFS_H_DIR/confdefs.h.281: No such file or directory
21.03 yes
21.03 ./configure: line 51811: CONFDEFS_H_DIR/confdefs.h.295: No such file or directory
21.03 yes
21.03 ./configure: line 51655: CONFDEFS_H_DIR/confdefs.h.294: No such file or directory
21.06 yes
21.06 ./configure: line 48260: CONFDEFS_H_DIR/confdefs.h.275: No such file or directory
21.07 yes
21.07 ./configure: line 51199: CONFDEFS_H_DIR/confdefs.h.291: No such file or directory
21.09 yes
21.09 ./configure: line 51047: CONFDEFS_H_DIR/confdefs.h.290: No such file or directory
21.10 yes
21.10 ./configure: line 51503: CONFDEFS_H_DIR/confdefs.h.293: No such file or directory
21.10 yes
21.10 ./configure: line 51351: CONFDEFS_H_DIR/confdefs.h.292: No such file or directory
21.18 no
21.20 no
21.22 yes
21.22 ./configure: line 51967: CONFDEFS_H_DIR/confdefs.h.296: No such file or directory
21.25 yes
21.25 ./configure: line 47348: CONFDEFS_H_DIR/confdefs.h.269: No such file or directory
21.30 yes
21.30 ./configure: line 47038: CONFDEFS_H_DIR/confdefs.h.267: No such file or directory
21.30 yes
21.30 ./configure: line 46726: CONFDEFS_H_DIR/confdefs.h.265: No such file or directory
21.31 yes
21.31 ./configure: line 47194: CONFDEFS_H_DIR/confdefs.h.268: No such file or directory
21.33 yes
21.33 ./configure: line 46882: CONFDEFS_H_DIR/confdefs.h.266: No such file or directory
21.34 yes
21.34 ./configure: line 47804: CONFDEFS_H_DIR/confdefs.h.272: No such file or directory
21.34 no
21.35 yes
21.35 ./configure: line 46574: CONFDEFS_H_DIR/confdefs.h.264: No such file or directory
21.43 yes
21.43 ./configure: line 50709: CONFDEFS_H_DIR/confdefs.h.288: No such file or directory
21.44 no
21.44 yes
21.44 ./configure: line 50539: CONFDEFS_H_DIR/confdefs.h.287: No such file or directory
21.48 yes
21.48 ./configure: line 48872: CONFDEFS_H_DIR/confdefs.h.279: No such file or directory
21.49 yes
21.49 ./configure: line 49494: CONFDEFS_H_DIR/confdefs.h.283: No such file or directory
21.51 yes
21.51 ./configure: line 49650: CONFDEFS_H_DIR/confdefs.h.284: No such file or directory
21.53 yes
21.53 ./configure: line 47954: CONFDEFS_H_DIR/confdefs.h.273: No such file or directory
21.54 yes
21.54 ./configure: line 48104: CONFDEFS_H_DIR/confdefs.h.274: No such file or directory
21.54 checking if scsi_done is defind... checking if scsi_get_sector is defind... checking if string.h has strscpy_pad... checking if net_namespace get const struct device... checking if dev_uevent get const struct device... checking if devnode get const struct device... checking if bus_type enty of struct device is const... checking if bus_find_device get const... checking if netns_ipv4 tcp_death_row memebr is not pointer... checking if netdevice.h if struct rtnl_link_ops has netns_refund... checking if linux/eventfd.h has eventfd_signal with 1 param... checking if net/ipv6.h has struct hop_jumbo_hdr... checking if netdevice.h has netdev_xmit_more... checking if mm.h has FOLL_LONGTERM... checking if linux/dma-mapping.h has dma_pci_p2pdma_supported... checking if linux/proc_fs.h has pde_data... checking if linux/proc_fs.h has struct proc_ops... checking if blk_mark_disk_dead exist... checking if dma-mapping.h has dma_zalloc_coherent function... checking if net/xdp.h has xdp_set_features_flag... checking if net/xdp_sock_drv.h has xsk_buff_alloc... checking if net/xdp_sock_drv.h has xsk_buff_alloc_batch... checking if net/xdp_sock_drv.h has xsk_buff_set_size... checking if net/xdp_sock_drv.h has xsk_buff_xdp_get_frame_dma... checking if kernel supports v6.10-rc1, skip calling no-op sync ops when possible... checking if kernel supports v6.10-rc1: convert __be16 tunnel flags to bitmaps... checking if net/xdp_sock.h has struct xsk_tx_metadata_ops... checking if net/xdp_sock.h has xsk_umem_release_addr_rq... checking if net/xdp_sock.h has xsk_umem_adjust_offset... checking if net/xdp_soc_drv.h has xsk_umem_consume_tx get 2 params... checking if net/xdp_sock.h has xsk_umem_consume_tx get 2 params... checking if xdp_sock.h struct xdp_umem has member chunk_size... checking if xdp_sock.h struct xdp_umem has member flags... yes
22.50 ./configure: line 52575: CONFDEFS_H_DIR/confdefs.h.300: No such file or directory
22.64 no
22.67 yes
22.67 ./configure: line 53543: CONFDEFS_H_DIR/confdefs.h.306: No such file or directory
22.81 yes
22.81 ./configure: line 52741: CONFDEFS_H_DIR/confdefs.h.301: No such file or directory
22.82 yes
22.82 ./configure: line 52905: CONFDEFS_H_DIR/confdefs.h.302: No such file or directory
22.85 yes
22.85 ./configure: line 53069: CONFDEFS_H_DIR/confdefs.h.303: No such file or directory
22.85 yes
22.85 ./configure: line 53227: CONFDEFS_H_DIR/confdefs.h.304: No such file or directory
22.86 yes
22.86 ./configure: line 53381: CONFDEFS_H_DIR/confdefs.h.305: No such file or directory
22.93 no
22.93 no
22.95 yes
22.95 ./configure: line 54617: CONFDEFS_H_DIR/confdefs.h.313: No such file or directory
22.95 yes
22.95 ./configure: line 54781: CONFDEFS_H_DIR/confdefs.h.314: No such file or directory
22.97 yes
22.97 ./configure: line 54313: CONFDEFS_H_DIR/confdefs.h.311: No such file or directory
22.99 yes
22.99 ./configure: line 54465: CONFDEFS_H_DIR/confdefs.h.312: No such file or directory
23.06 yes
23.06 ./configure: line 52423: CONFDEFS_H_DIR/confdefs.h.299: No such file or directory
23.06 yes
23.06 ./configure: line 52119: CONFDEFS_H_DIR/confdefs.h.297: No such file or directory
23.07 yes
23.07 ./configure: line 54931: CONFDEFS_H_DIR/confdefs.h.315: No such file or directory
23.08 yes
23.08 ./configure: line 52271: CONFDEFS_H_DIR/confdefs.h.298: No such file or directory
23.17 no
23.18 no
23.18 no
23.19 no
23.20 yes
23.20 ./configure: line 53701: CONFDEFS_H_DIR/confdefs.h.307: No such file or directory
23.24 yes
23.24 ./configure: line 57087: CONFDEFS_H_DIR/confdefs.h.329: No such file or directory
23.26 yes
23.26 ./configure: line 55693: CONFDEFS_H_DIR/confdefs.h.320: No such file or directory
23.27 yes
23.27 ./configure: line 54161: CONFDEFS_H_DIR/confdefs.h.310: No such file or directory
23.27 no
23.29 yes
23.29 ./configure: line 55845: CONFDEFS_H_DIR/confdefs.h.321: No such file or directory
23.30 yes
23.30 ./configure: line 54009: CONFDEFS_H_DIR/confdefs.h.309: No such file or directory
23.31 yes
23.31 ./configure: line 55237: CONFDEFS_H_DIR/confdefs.h.317: No such file or directory
23.31 yes
23.31 ./configure: line 55389: CONFDEFS_H_DIR/confdefs.h.318: No such file or directory
23.31 no
23.32 yes
23.32 ./configure: line 55541: CONFDEFS_H_DIR/confdefs.h.319: No such file or directory
23.32 checking if filter.h has xdp_do_flush_map... checking if filter.h has bpf_warn_invalid_xdp_action get 3 params... checking if scsi.h has QUEUE_FULL... checking if scsi_device.h has scsi_block_targets... checking if iscsi_target_core.h has struct iscsit_conn... checking if iscsi_target_core.h struct iscsit_conn has member login_sockaddr... checking if iscsi_target_core.h struct iscsit_conn has member local_sockaddr... checking if iscsi_target_core.h struct iscsi_conn has member login_sockaddr... checking if iscsi_target_core.h struct iscsi_conn has member local_sockaddr... checking if iscsi_target_core.h has struct iscsit_cmd... checking if target/target_core_fabric.h has target_stop_session... checking if target/target_core_fabric.h has target_stop_cmd_counter... checking if scsi_host.h struct scsi_host_template has member shost_groups... checking if scsi_host.h struct scsi_host_template has member init_cmd_priv... checking if scsi_host.h struct Scsi_Host has member max_segment_size... checking if scsi_host.h struct Scsi_Host has member virt_boundary_mask... checking if scsi_host.h scsi_host_busy_iter fn has 2 args... checking if scsi_host.h has enum scsi_timeout_action... checking if scsi_host_alloc get const struct scsi_host_template... checking if target_core_base.h struct se_cmd has member sense_info... checking if scsi_device.h struct scsi_device has member budget_map... checking if linux/blk_types.h has enum req_opf... checking if __cgroup_bpf_run_filter_sysctl have 7 parameters... checking if linux/pci-p2pdma.h exists... checking if trace/events/rdma_core.h exists... checking if __assign_str has one param... checking if pci-p2pdma.h has pci_p2pdma_unmap_sg... checking if struct bpf_prog_aux has xdp_has_frags as member... checking if net/xdp.h has xdp_update_skb_shared_info... checking if xdp_metadata_ops has xmo_rx_vlan_tag... checking if net/xdp.h has xdp_get_shared_info_from_buff... checking if Linux was built with symbol tcf_exts_num_actions exported... yes
23.33 checking if Linux was built with symbol netpoll_poll_dev exported... yes
23.34 checking if Linux was built with symbol __put_task_struct exported... yes
23.34 checking if Linux was built with symbol mmput_async exported... yes
23.34 checking if Linux was built with symbol get_pid_task exported... yes
23.34 checking if Linux was built with symbol get_task_pid exported... yes
23.34 checking if Linux was built with symbol mm_kobj exported... no
23.34 checking if bpf_prog_add\bfs_prog_inc functions return struct... checking if struct tc_cls_flower_offload has common... no
24.56 yes
24.56 ./configure: line 59093: CONFDEFS_H_DIR/confdefs.h.342: No such file or directory
24.59 yes
24.59 ./configure: line 58941: CONFDEFS_H_DIR/confdefs.h.341: No such file or directory
24.61 yes
24.61 ./configure: line 60341: CONFDEFS_H_DIR/confdefs.h.350: No such file or directory
24.72 no
24.73 no
24.75 no
24.80 yes
24.80 ./configure: line 58319: CONFDEFS_H_DIR/confdefs.h.337: No such file or directory
24.81 no
24.82 yes
24.82 ./configure: line 58003: CONFDEFS_H_DIR/confdefs.h.335: No such file or directory
24.82 no
24.84 yes
24.84 ./configure: line 58161: CONFDEFS_H_DIR/confdefs.h.336: No such file or directory
24.84 yes
24.84 ./configure: line 58787: CONFDEFS_H_DIR/confdefs.h.340: No such file or directory
24.85 yes
24.85 no
24.85 ./configure: line 61567: CONFDEFS_H_DIR/confdefs.h.358: No such file or directory
24.87 yes
24.87 ./configure: line 60943: CONFDEFS_H_DIR/confdefs.h.354: No such file or directory
24.91 yes
24.91 ./configure: line 59247: CONFDEFS_H_DIR/confdefs.h.343: No such file or directory
24.92 yes
24.92 ./configure: line 60027: CONFDEFS_H_DIR/confdefs.h.348: No such file or directory
24.92 yes
24.92 ./configure: line 59713: CONFDEFS_H_DIR/confdefs.h.346: No such file or directory
24.92 yes
24.92 ./configure: line 60495: CONFDEFS_H_DIR/confdefs.h.351: No such file or directory
24.93 yes
24.93 ./configure: line 59401: CONFDEFS_H_DIR/confdefs.h.344: No such file or directory
24.93 yes
24.93 ./configure: line 60183: CONFDEFS_H_DIR/confdefs.h.349: No such file or directory
24.95 yes
24.95 ./configure: line 59557: CONFDEFS_H_DIR/confdefs.h.345: No such file or directory
24.95 yes
24.95 ./configure: line 59875: CONFDEFS_H_DIR/confdefs.h.347: No such file or directory
24.95 yes
24.95 ./configure: line 57851: CONFDEFS_H_DIR/confdefs.h.334: No such file or directory
25.00 yes
25.00 ./configure: line 60795: CONFDEFS_H_DIR/confdefs.h.353: No such file or directory
25.00 no
25.04 yes
25.04 ./configure: line 57395: CONFDEFS_H_DIR/confdefs.h.331: No such file or directory
25.07 yes
25.07 ./configure: line 62031: CONFDEFS_H_DIR/confdefs.h.361: No such file or directory
25.07 yes
25.07 ./configure: line 61719: CONFDEFS_H_DIR/confdefs.h.359: No such file or directory
25.07 yes
25.08 ./configure: line 57243: CONFDEFS_H_DIR/confdefs.h.330: No such file or directory
25.08 yes
25.08 ./configure: line 57547: CONFDEFS_H_DIR/confdefs.h.332: No such file or directory
25.13 yes
25.13 ./configure: line 61091: CONFDEFS_H_DIR/confdefs.h.355: No such file or directory
25.13 checking if struct flow_cls_offload exists... checking if struct flow_action_entry has ct_metadata.orig_dir... checking if struct flow_action_entry has ptype... checking if struct flow_action_entry has mpls... checking if struct flow_action_entry has police.index... checking if struct flow_action_entry has police.exceed... checking if struct flow_action_entry has hw_index... checking if struct flow_action_entry has police.rate_pkt_ps... checking if flow_rule_match_meta exists... checking if flow_action_hw_stats_check exists... checking if FLOW_ACTION_POLICE exists... checking if FLOW_ACTION_CT exists... checking if FLOW_ACTION_REDIRECT_INGRESS exists... checking if enum flow_block_binder_type exists... checking if flow_indr_block_bind_cb_t has 7 parameters... checking if flow_indr_block_bind_cb_t has 4 parameters... checking if flow_indr_dev_unregister receive flow_setup_cb_t parameter... checking if flow_indr_dev_register exist... checking if flow_stats_update has 5 parameters... checking if flow_stats_update has 6 parameters... checking if GRO_LEGACY_MAX_SIZE defined... checking if GRO_MAX_SIZE defined... checking if struct mlx5e_netdev_ops has ndo_tx_timeout get 2 params... checking if net/tc_act/tc_mpls.h exists... checking if net/tc_act/tc_pedit.h struct tcf_pedit has member tcfp_keys_ex... checking if net/tc_act/tc_pedit.h struct tcf_pedit_parms has member tcfp_keys_ex... checking if libiscsi.h has iscsi_eh_cmd_timed_out... checking if libiscsi.h has iscsi_conn_unbind... checking if libiscsi.h iscsi_host_remove has 2 parameters... checking if libiscsi.h has struct iscsi_cmd... checking if scsi_transport_iscsi.h has iscsi_put_endpoint... checking if linux/sed-opal.h exists... checking if bio.h bio_init has 3 parameters... yes
26.17 ./configure: line 67502: CONFDEFS_H_DIR/confdefs.h.395: No such file or directory
26.70 yes
26.70 ./configure: line 67354: CONFDEFS_H_DIR/confdefs.h.394: No such file or directory
26.76 no
26.77 no
26.79 no
26.81 yes
26.81 ./configure: line 63503: CONFDEFS_H_DIR/confdefs.h.369: No such file or directory
26.82 yes
26.82 ./configure: line 63657: CONFDEFS_H_DIR/confdefs.h.370: No such file or directory
26.83 yes
26.83 ./configure: line 63195: CONFDEFS_H_DIR/confdefs.h.367: No such file or directory
26.83 yes
26.83 yes
26.83 ./configure: line 62887: CONFDEFS_H_DIR/confdefs.h.365: No such file or directory
26.83 ./configure: line 67202: CONFDEFS_H_DIR/confdefs.h.393: No such file or directory
26.83 yes
26.83 ./configure: line 64111: CONFDEFS_H_DIR/confdefs.h.373: No such file or directory
26.84 yes
26.84 ./configure: line 64411: CONFDEFS_H_DIR/confdefs.h.375: No such file or directory
26.84 yes
26.84 ./configure: line 66898: CONFDEFS_H_DIR/confdefs.h.391: No such file or directory
26.84 yes
26.84 ./configure: line 63041: CONFDEFS_H_DIR/confdefs.h.366: No such file or directory
26.85 yes
26.85 ./configure: line 62733: CONFDEFS_H_DIR/confdefs.h.364: No such file or directory
26.85 yes
26.85 ./configure: line 67050: CONFDEFS_H_DIR/confdefs.h.392: No such file or directory
26.85 yes
26.85 ./configure: line 65666: CONFDEFS_H_DIR/confdefs.h.383: No such file or directory
26.86 yes
26.86 ./configure: line 64561: CONFDEFS_H_DIR/confdefs.h.376: No such file or directory
26.86 yes
26.86 ./configure: line 64713: CONFDEFS_H_DIR/confdefs.h.377: No such file or directory
26.86 yes
26.86 ./configure: line 63961: CONFDEFS_H_DIR/confdefs.h.372: No such file or directory
26.86 yes
26.86 ./configure: line 64261: CONFDEFS_H_DIR/confdefs.h.374: No such file or directory
26.86 yes
26.86 ./configure: line 63811: CONFDEFS_H_DIR/confdefs.h.371: No such file or directory
26.88 no
26.89 yes
26.89 ./configure: line 65970: CONFDEFS_H_DIR/confdefs.h.385: No such file or directory
26.91 no
26.91 no
26.91 yes
26.91 ./configure: line 65818: CONFDEFS_H_DIR/confdefs.h.384: No such file or directory
26.91 no
26.95 yes
26.95 ./configure: line 65366: CONFDEFS_H_DIR/confdefs.h.381: No such file or directory
26.95 yes
26.95 ./configure: line 66136: CONFDEFS_H_DIR/confdefs.h.386: No such file or directory
26.96 yes
26.97 ./configure: line 64883: CONFDEFS_H_DIR/confdefs.h.378: No such file or directory
26.97 yes
26.97 ./configure: line 66284: CONFDEFS_H_DIR/confdefs.h.387: No such file or directory
26.97 yes
26.97 ./configure: line 66592: CONFDEFS_H_DIR/confdefs.h.389: No such file or directory
26.97 checking if __auto_type exists... checking if compiler.h has const __read_once_size... checking if linux/security.h has register_lsm_notifier... checking if linux/security.h has register_blocking_lsm_notifier... checking if linux/dma-map-ops.h has DMA_F_PCI_P2PDMA_SUPPORTED... checking if linux/atomic.h has __atomic_add_unless... checking if linux/atomic.h has atomic_fetch_add_unless... checking if net/pkt_cls.h has tcf_exts_stats_update... checking if struct  tc_action_ops has id... checking if linux/device/bus.h exists... checking if bus_type remove function return void... checking if blkdev.h has BLK_INTEGRITY_DEVICE_CAPABLE... checking if blkdev.h has BLK_MAX_WRITE_HINTS... checking if genhd.h has device_add_disk... checking if genhd.h has device_add_disk 3 args... checking if genhd.h has device_add_disk 3 args and must_check... checking if list_is_first is defined... checking if linux/scatterlist.h _sg_alloc_table_from_pages has 9 params... checking if linux/scatterlist.h has sg_append_table... checking if linux/dma-resv.h exists... checking if linux/dma-resv.h has DMA_RESV_USAGE_KERNEL... checking if linux/dma-resv.h has dma_resv_wait_timeout... checking if linux/dma-resv.h has dma_resv_excl_fence... checking if dma_buf_dynamic_attach get 4 params... checking if struct dma_buf_attach_ops has allow_peer2peer... checking if netif_napi_add get 3 params... checking if netdevice.h has netif_napi_add_weight... checking if bareudp.h has netif_is_bareudp... checking if netdevice.h has TC_SETUP_FT... checking if ib_umem_notifier_invalidate_range_start has parameter blockable... checking if iscsit_set_unsolicited_dataout is defined... checking if mmu_notifier.h has mmu_notifier_call_srcu... checking if mmu_notifier.h has mmu_notifier_synchronize... no
27.87 yes
27.87 ./configure: line 70260: CONFDEFS_H_DIR/confdefs.h.413: No such file or directory
27.89 ./configure: line 67816: CONFDEFS_H_DIR/confdefs.h.397: No such file or directory
27.89 yes
28.07 no
28.08 no
28.13 no
28.20 yes
28.20 ./configure: line 70716: CONFDEFS_H_DIR/confdefs.h.416: No such file or directory
28.21 yes
28.21 ./configure: line 70868: CONFDEFS_H_DIR/confdefs.h.417: No such file or directory
28.22 yes
28.22 ./configure: line 69348: CONFDEFS_H_DIR/confdefs.h.407: No such file or directory
28.23 yes
28.23 ./configure: line 69184: CONFDEFS_H_DIR/confdefs.h.406: No such file or directory
28.27 yes
28.27 ./configure: line 71016: CONFDEFS_H_DIR/confdefs.h.418: No such file or directory
28.32 no
28.36 yes
28.36 ./configure: line 68428: CONFDEFS_H_DIR/confdefs.h.401: No such file or directory
28.38 yes
28.38 ./configure: line 70568: CONFDEFS_H_DIR/confdefs.h.415: No such file or directory
28.40 yes
28.40 ./configure: line 68274: CONFDEFS_H_DIR/confdefs.h.400: No such file or directory
28.40 no
28.40 yes
28.40 ./configure: line 68732: CONFDEFS_H_DIR/confdefs.h.403: No such file or directory
28.41 no
28.42 yes
28.42 ./configure: line 71472: CONFDEFS_H_DIR/confdefs.h.421: No such file or directory
28.43 no
28.44 no
28.44 yes
28.44 ./configure: line 72398: CONFDEFS_H_DIR/confdefs.h.427: No such file or directory
28.44 yes
28.44 ./configure: line 71316: CONFDEFS_H_DIR/confdefs.h.420: No such file or directory
28.44 no
28.46 yes
28.46 ./configure: line 70110: CONFDEFS_H_DIR/confdefs.h.412: No such file or directory
28.47 yes
28.47 ./configure: line 69956: CONFDEFS_H_DIR/confdefs.h.411: No such file or directory
28.49 no
28.57 no
28.59 yes
28.59 ./configure: line 71624: CONFDEFS_H_DIR/confdefs.h.422: No such file or directory
28.60 yes
28.60 ./configure: line 72080: CONFDEFS_H_DIR/confdefs.h.425: No such file or directory
28.62 yes
28.62 ./configure: line 71776: CONFDEFS_H_DIR/confdefs.h.423: No such file or directory
28.65 yes
28.65 ./configure: line 71928: CONFDEFS_H_DIR/confdefs.h.424: No such file or directory
28.65 yes
28.65 ./configure: line 69036: CONFDEFS_H_DIR/confdefs.h.405: No such file or directory
28.65 checking if mmu_notifier.h has mmu_notifier_range_blockable... checking if struct mmu_notifier_ops has free_notifier ... checking if ib_umem_notifier_invalidate_range_start get struct mmu_notifier_range ... checking if mmu_notifier.h has mmu_notifier_unregister_no_release... checking if have mmu interval notifier... checking if blkdev.h has __blkdev_issue_discard... checking if __blkdev_issue_discard has 5 params... checking if struct bio has member bi_disk... checking if fs.h has stream_open... checking if pnv-pci.h has pnv_pci_set_p2p... checking if Linux was built with symbol interval_tree_insert exported... yes
28.65 checking if act_apt.h tc_setup_cb_egdev_register... checking if act_api.h has tcf_action_stats_update... checking if act_api.h has tcf_action_stats_update with 5 params... checking if linux/uio.h has iov_iter_is_bvec... checking if struct xfrmdev_ops has member xdo_dev_state_add get extack... checking if struct xfrmdev_ops has member xdo_dev_policy_add get extack... checking if struct xfrmdev_ops has member xdo_dev_policy_add... checking if struct xfrmdev_ops has member xdo_dev_state_update_curlft... checking if struct xfrmdev_ops has member xdo_dev_state_update_stats... checking if interrupt.h has irq_affinity_desc... checking if interrupt.h has irq_set_affinity_and_hint... checking if linux/overflow.h has size_add size_mul size_sub... checking if function kvfree_call_rcu is defined... checking if function kfree_rcu_mightsleep is defined... checking if net/xdp.h has xdp_init_buff... checking if net/xdp.h has __xdp_rxq_info_reg... checking if net/xdp.h has xdp_rxq_info_reg get 4 params... checking if net/xdp.h struct xdp_frame_bulk exists... checking if xdp_buff has flags as member... checking if xdp_buff has frame_sz as member... checking if net/xdp.h has xdp_convert_buff_to_frame... checking if net/xdp.h has convert_to_xdp_frame... checking if net/xdp.h has convert_to_xdp_frame workaround for 5.4.17-2011.1.2.el8uek.x86_64... no
29.57 yes
29.58 ./configure: line 76145: CONFDEFS_H_DIR/confdefs.h.451: No such file or directory
29.75 no
29.79 yes
29.79 ./configure: line 76297: CONFDEFS_H_DIR/confdefs.h.452: No such file or directory
29.80 yes
29.80 ./configure: line 72698: CONFDEFS_H_DIR/confdefs.h.429: No such file or directory
29.81 yes
29.81 ./configure: line 76449: CONFDEFS_H_DIR/confdefs.h.453: No such file or directory
29.82 yes
29.82 ./configure: line 73167: CONFDEFS_H_DIR/confdefs.h.432: No such file or directory
29.82 yes
29.82 ./configure: line 72853: CONFDEFS_H_DIR/confdefs.h.430: No such file or directory
29.82 yes
29.82 ./configure: line 73473: CONFDEFS_H_DIR/confdefs.h.434: No such file or directory
29.83 yes
29.83 ./configure: line 73005: CONFDEFS_H_DIR/confdefs.h.431: No such file or directory
29.83 yes
29.84 ./configure: line 75985: CONFDEFS_H_DIR/confdefs.h.450: No such file or directory
29.84 yes
29.84 ./configure: line 75833: CONFDEFS_H_DIR/confdefs.h.449: No such file or directory
29.84 yes
29.84 ./configure: line 74877: CONFDEFS_H_DIR/confdefs.h.443: No such file or directory
30.04 no
30.05 yes
30.05 ./configure: line 74081: CONFDEFS_H_DIR/confdefs.h.438: No such file or directory
30.10 no
30.13 yes
30.13 ./configure: line 73777: CONFDEFS_H_DIR/confdefs.h.436: No such file or directory
30.20 no
30.26 no
30.27 no
30.28 yes
30.28 ./configure: line 75213: CONFDEFS_H_DIR/confdefs.h.445: No such file or directory
30.28 no
30.29 yes
30.29 ./configure: line 77211: CONFDEFS_H_DIR/confdefs.h.458: No such file or directory
30.29 yes
30.29 ./configure: line 75045: CONFDEFS_H_DIR/confdefs.h.444: No such file or directory
30.29 yes
30.29 ./configure: line 75525: CONFDEFS_H_DIR/confdefs.h.447: No such file or directory
30.32 no
30.32 yes
30.32 ./configure: line 75369: CONFDEFS_H_DIR/confdefs.h.446: No such file or directory
30.32 yes
30.32 ./configure: line 76601: CONFDEFS_H_DIR/confdefs.h.454: No such file or directory
30.32 yes
30.32 ./configure: line 77057: CONFDEFS_H_DIR/confdefs.h.457: No such file or directory
30.37 yes
30.37 ./configure: line 76753: CONFDEFS_H_DIR/confdefs.h.455: No such file or directory
30.37 yes
30.37 ./configure: line 77517: CONFDEFS_H_DIR/confdefs.h.460: No such file or directory
30.38 yes
30.38 ./configure: line 77365: CONFDEFS_H_DIR/confdefs.h.459: No such file or directory
30.40 yes
30.40 ./configure: line 76905: CONFDEFS_H_DIR/confdefs.h.456: No such file or directory
30.40 checking if struct vdpa_config_ops has get_vq_dma_dev... checking if struct vdpa_config_ops has resume... checking if struct vdpa_config_ops has get_vq_dma_dev... checking if struct vdpa_config_ops has .get_vq_desc_group and .compat_reset... checking if vdpa_dev_set_config has device_features... checking if struct vfio_device_ops has iommufd support... checking if struct vfio_device_ops has detach_ioas... checking if has vfio_combine_iova_ranges... checking if has sturct vfio_precopy_info... checking if has vfio_pci_core_init_dev... checking if linux/vfio_pci_core.h exists... checking if net/gro.h exists... checking if net/page_pool.h struct page_pool_params has napi as member... checking if net/page_pool/types.h struct page_pool_params has napi as member... checking if net/page_pool/types.h struct page_pool_params has netdev as member... checking if net/page_pool.h page_pool_get_dma_addr defined... checking if net/page_pool/helpers.h page_pool_get_dma_addr defined... checking if net/nexthop.h exists... checking if net/page_pool.h exists... checking if net/page_pool/types.h exists... checking if net/page_pool.h has page_pool_release_page... checking if net/page_pool/types.h has page_pool_release_page... checking if net/page_pool/types.h has page_pool_put_unrefed_page... checking if net/page_pool/types.h has page_pool_put_defragged_page... checking if net/page_pool.h has page_pool_put_defragged_page... checking if net/page_pool.h has page_pool_nid_changed... checking if net/page_pool/helpers.h has page_pool_nid_changed... checking if net/tls.h has tls_driver_ctx... checking if net/tls.h has tls_offload_rx_force_resync_request... checking if have blk_queue_make_request... checking if have put_unaligned_le24... checking for include/linux/part_stat.h... checking if netdev_bpf struct has pool member... no
31.23 no
31.23 no
31.23 no
31.24 no
31.24 no
31.24 no
31.28 no
31.68 no
31.69 yes
31.69 ./configure: line 80893: CONFDEFS_H_DIR/confdefs.h.482: No such file or directory
31.73 yes
31.73 ./configure: line 80449: CONFDEFS_H_DIR/confdefs.h.479: No such file or directory
31.73 no
31.77 yes
31.77 ./configure: line 78921: CONFDEFS_H_DIR/confdefs.h.469: No such file or directory
31.78 no
31.80 yes
31.80 ./configure: line 81944: CONFDEFS_H_DIR/confdefs.h.489: No such file or directory
31.80 yes
31.80 ./configure: line 79985: CONFDEFS_H_DIR/confdefs.h.476: No such file or directory
31.82 yes
31.82 ./configure: line 79225: CONFDEFS_H_DIR/confdefs.h.471: No such file or directory
31.82 yes
31.82 yes
31.82 ./configure: line 81494: CONFDEFS_H_DIR/confdefs.h.486: No such file or directory
31.82 ./configure: line 79073: CONFDEFS_H_DIR/confdefs.h.470: No such file or directory
31.84 yes
31.84 yes
31.84 ./configure: line 79525: CONFDEFS_H_DIR/confdefs.h.473: No such file or directory
31.84 ./configure: line 78764: CONFDEFS_H_DIR/confdefs.h.468: No such file or directory
31.84 no
31.88 no
31.89 yes
31.89 ./configure: line 79377: CONFDEFS_H_DIR/confdefs.h.472: No such file or directory
31.91 yes
31.91 ./configure: line 82700: CONFDEFS_H_DIR/confdefs.h.494: No such file or directory
32.01 yes
32.01 ./configure: line 78135: CONFDEFS_H_DIR/confdefs.h.464: No such file or directory
32.05 yes
32.05 ./configure: line 78603: CONFDEFS_H_DIR/confdefs.h.467: No such file or directory
32.06 yes
32.06 ./configure: line 80597: CONFDEFS_H_DIR/confdefs.h.480: No such file or directory
32.07 yes
32.07 ./configure: line 77979: CONFDEFS_H_DIR/confdefs.h.463: No such file or directory
32.08 yes
32.08 ./configure: line 78291: CONFDEFS_H_DIR/confdefs.h.465: No such file or directory
32.09 no
32.11 yes
32.11 ./configure: line 82096: CONFDEFS_H_DIR/confdefs.h.490: No such file or directory
32.12 yes
32.12 ./configure: line 79673: CONFDEFS_H_DIR/confdefs.h.474: No such file or directory
32.12 checking if memremap.h has is_pci_p2pdma_page... checking if mm.h has gup_must_unshare get 3 params... checking if mm.h has assert_fault_locked... checking if mm.h has is_pci_p2pdma_page... checking if mm.h has release_pages... checking if t10-pi.h has t10_pi_prepare... checking if linux/blk-mq.h has busy_tag_iter_fn return bool with 2 params... checking if linux/blk-mq.h has busy_tag_iter_fn return bool with 3 params... checking if struct blk_mq_ops has poll 1 arg... checking if bitmap.h bitmap_zalloc_node... checking if dma-mapping.h has dma_map_sgtable... checking if tc_htb_command has moved_qid... checking if blk-mq.h has blk_mq_complete_request_sync... checking if linux/blk_types.h has REQ_HIPRI... checking if interrupt.h has tasklet_setup... checking if dma_map_bvec exist... checking if flow_indr_block_cb_alloc exist... checking if struct flow_block_cb exist... checking if linux/scatterlist.h sg_alloc_table_chained has nents_first_chunk parameter... checking if linux/blk-mq.h has request_to_qc_t... checking if linux/blk-mq.h has blk_mq_request_completed... checking if linux/blk-mq.h has blk_mq_tagset_wait_completed_request... checking if *xpo_secure_port returns void... checking if struct svc_rqst has rq_xprt_hlen... checking if struct svc_serv has sv_cb_list... checking if Linux was built with symbol svc_pool_wake_idle_thread exported... no
32.13 checking if *send_request has 'struct rpc_rqst *req' as a param... checking for xprt_request_get_cong... checking for "xpo_secure_port" inside "struct svc_xprt_ops"... checking for "xpo_prep_reply_hdr" inside "struct svc_xprt_ops"... checking for "xpo_read_payload" inside "struct svc_xprt_ops"... checking for "xpo_result_payload" inside "struct svc_xprt_ops"... checking for "xpo_release_ctxt" inside "struct svc_xprt_ops"... yes
33.11 ./configure: line 84412: CONFDEFS_H_DIR/confdefs.h.505: No such file or directory
33.30 yes
33.30 ./configure: line 85172: CONFDEFS_H_DIR/confdefs.h.510: No such file or directory
33.42 yes
33.42 ./configure: line 83008: CONFDEFS_H_DIR/confdefs.h.496: No such file or directory
33.56 no
33.59 yes
33.60 no
33.60 ./configure: line 84562: CONFDEFS_H_DIR/confdefs.h.506: No such file or directory
33.60 no
33.60 no
33.61 no
33.62 yes
33.62 no
33.62 ./configure: line 85786: CONFDEFS_H_DIR/confdefs.h.514: No such file or directory
33.62 no
33.62 yes
33.62 ./configure: line 83464: CONFDEFS_H_DIR/confdefs.h.499: No such file or directory
33.64 yes
33.64 ./configure: line 83312: CONFDEFS_H_DIR/confdefs.h.498: No such file or directory
33.64 no
33.66 no
33.67 no
33.68 yes
33.68 ./configure: line 83616: CONFDEFS_H_DIR/confdefs.h.500: No such file or directory
33.68 no
33.69 no
33.69 yes
33.69 ./configure: line 86878: CONFDEFS_H_DIR/confdefs.h.521: No such file or directory
33.70 no
33.72 yes
33.72 ./configure: line 87850: CONFDEFS_H_DIR/confdefs.h.527: No such file or directory
33.72 yes
33.72 ./configure: line 85482: CONFDEFS_H_DIR/confdefs.h.512: No such file or directory
33.73 yes
33.73 ./configure: line 85330: CONFDEFS_H_DIR/confdefs.h.511: No such file or directory
33.73 yes
33.73 ./configure: line 85634: CONFDEFS_H_DIR/confdefs.h.513: No such file or directory
33.74 yes
33.74 ./configure: line 86090: CONFDEFS_H_DIR/confdefs.h.516: No such file or directory
33.74 yes
33.74 ./configure: line 86242: CONFDEFS_H_DIR/confdefs.h.517: No such file or directory
33.75 yes
33.75 ./configure: line 87226: CONFDEFS_H_DIR/confdefs.h.523: No such file or directory
33.75 yes
33.75 ./configure: line 83930: CONFDEFS_H_DIR/confdefs.h.502: No such file or directory
33.76 yes
33.76 ./configure: line 87078: CONFDEFS_H_DIR/confdefs.h.522: No such file or directory
33.76 no
33.93 yes
33.93 ./configure: line 82856: CONFDEFS_H_DIR/confdefs.h.495: No such file or directory
33.93 checking for "set_retrans_timeout" inside "struct rpc_xprt_ops"... checking for "wait_for_reply_request" inside "struct rpc_xprt_ops"... checking for "queue_lock" inside "struct rpc_xprt"... checking if xprt_wait_for_buffer_space has xprt as a parameter... checking for "recv_lock" inside "struct rpc_xprt"... checking for "xprt_class" inside "struct rpc_xprt"... checking if Linux was built with symbol xprt_reconnect_delay exported... yes
33.93 checking for "bc_num_slots" inside "struct rpc_xprt_ops"... checking for "bc_up" inside "struct rpc_xprt_ops"... checking for "netid" inside "struct xprt_class"... checking if linux/sysctl.h has SYSCTL_ZERO... checking for "child" field inside "struct ctl_table"... checking if defined XDRBUF_SPARSE_PAGES... checking if xdr_init_encode has rqst as a parameter... checking if xdr_init_decode has rqst as a parameter... checking for "rc_stream" inside "struct svc_rdma_recv_ctxt"... checking for "sc_pending_recvs" inside "struct svcxprt_rdma"... checking if xdr_encode_rdma_segment has defined... checking if xdr_decode_rdma_segment has defined... checking if xdr_stream_encode_item_absent has defined... checking if xdr_item_is_absent has defined... checking if xdr_buf_subsegment get const... checking if svc_xprt_is_dead has defined... checking if svc_rdma_release_rqst has externed... checking if Linux was built with symbol xprt_add_backlog exported... yes
33.94 checking if Linux was built with symbol xprt_lock_connect exported... yes
33.94 checking if Linux was built with symbol svc_xprt_deferred_close exported... yes
33.94 checking if Linux was built with symbol svc_xprt_received exported... yes
33.94 checking if Linux was built with symbol svc_xprt_close exported... yes
33.95 checking for trace/events/rpcrdma.h... checking for struct svc_rdma_pcl... checking if class_create get 1 param... checking if show_class_attr_string get const... checking if class_register takes a const param... checking if netdevice.h has __netdev_tx_sent_queue... checking if msi_map exists... checking if flow_dissector.h enum flow_dissector_key_keyid has FLOW_DISSECTOR_KEY_META... checking if netif_is_geneve exists... checking if have netif_is_gretap... yes
34.87 ./configure: line 92869: CONFDEFS_H_DIR/confdefs.h.558: No such file or directory
34.88 yes
34.88 ./configure: line 93021: CONFDEFS_H_DIR/confdefs.h.559: No such file or directory
35.00 no
35.02 yes
35.03 ./configure: line 89605: CONFDEFS_H_DIR/confdefs.h.538: No such file or directory
35.19 ./configure: line 92565: CONFDEFS_H_DIR/confdefs.h.556: No such file or directory
35.19 yes
35.21 yes
35.21 ./configure: line 92251: CONFDEFS_H_DIR/confdefs.h.554: No such file or directory
35.21 yes
35.21 ./configure: line 92409: CONFDEFS_H_DIR/confdefs.h.555: No such file or directory
35.39 no
35.41 yes
35.41 ./configure: line 88006: CONFDEFS_H_DIR/confdefs.h.528: No such file or directory
35.41 yes
35.41 ./configure: line 91311: CONFDEFS_H_DIR/confdefs.h.549: No such file or directory
35.41 yes
35.41 ./configure: line 89917: CONFDEFS_H_DIR/confdefs.h.540: No such file or directory
35.43 yes
35.43 ./configure: line 90853: CONFDEFS_H_DIR/confdefs.h.546: No such file or directory
35.43 yes
35.43 ./configure: line 90699: CONFDEFS_H_DIR/confdefs.h.545: No such file or directory
35.44 yes
35.44 ./configure: line 91463: CONFDEFS_H_DIR/confdefs.h.550: No such file or directory
35.44 yes
35.44 ./configure: line 91005: CONFDEFS_H_DIR/confdefs.h.547: No such file or directory
35.45 yes
35.45 ./configure: line 90229: CONFDEFS_H_DIR/confdefs.h.542: No such file or directory
35.45 yes
35.45 ./configure: line 92097: CONFDEFS_H_DIR/confdefs.h.553: No such file or directory
35.45 yes
35.45 ./configure: line 90073: CONFDEFS_H_DIR/confdefs.h.541: No such file or directory
35.46 yes
35.46 ./configure: line 91157: CONFDEFS_H_DIR/confdefs.h.548: No such file or directory
35.47 no
35.47 no
35.48 yes
35.48 ./configure: line 88318: CONFDEFS_H_DIR/confdefs.h.530: No such file or directory
35.48 yes
35.48 ./configure: line 88632: CONFDEFS_H_DIR/confdefs.h.532: No such file or directory
35.52 yes
35.52 ./configure: line 89449: CONFDEFS_H_DIR/confdefs.h.537: No such file or directory
35.52 yes
35.52 ./configure: line 89137: CONFDEFS_H_DIR/confdefs.h.535: No such file or directory
35.53 yes
35.53 ./configure: line 88947: CONFDEFS_H_DIR/confdefs.h.534: No such file or directory
35.54 yes
35.54 ./configure: line 88476: CONFDEFS_H_DIR/confdefs.h.531: No such file or directory
35.66 no
35.67 yes
35.67 ./configure: line 92717: CONFDEFS_H_DIR/confdefs.h.557: No such file or directory
35.68 yes
35.68 ./configure: line 90545: CONFDEFS_H_DIR/confdefs.h.544: No such file or directory
35.76 yes
35.76 ./configure: line 93175: CONFDEFS_H_DIR/confdefs.h.560: No such file or directory
35.76 yes
35.76 ./configure: line 90389: CONFDEFS_H_DIR/confdefs.h.543: No such file or directory
35.84 yes
35.84 ./configure: line 91939: CONFDEFS_H_DIR/confdefs.h.552: No such file or directory
35.84 checking if have netif_is_vxlan... checking if uapi/linux/mei_uuid.h exists... checking if net/bareudp.h exists... checking if net/psample.h has struct psample_metadata... checking if netif_is_bareudp exists... checking if linux/blkdev.h has req_bvec... checking if pci-p2pdma.h has pci_p2pdma_map_sg_attrs... checking if uapi/linux/nvme_ioctl.h has struct nvme_passthru_cmd64... checking if struct request_queue has backing_dev_info... checking if linux/skbuff.h has skb_queue_empty_lockless... checking if struct pci_driver has member driver_managed_dma... checking if linux/pci.h has pcie_aspm_enabled... checking if net/macsec.h exists... checking if net/xdp_sock_drv.h exists... checking if xsk_buff_dma_sync_for_cpu get 2 params... checking if include/linux/units.h exists... checking if v6.6 remove sentinel from ctl_table array is supported... checking if linux/blkdev.h has bio_integrity_bytes... checking if include/net/esp.h has esp_output_fill_trailer... checking if blk_queue_max_active_zones exist... checking if genhd.h has set_capacity_revalidate_and_notify... checking if struct block_device_operations has submit_bio... checking if blk_queue_split has 1 param... checking if blkdev.h has bio_split_to_limits... checking if submit_bio_noacct exist... checking if linux/blk-mq.h has blk_should_fake_timeout... checking if linux/blk-mq.h has blk_mq_complete_request_remote... checking if trace_block_bio_complete has 2 param... checking if net/ip.h has ip_sock_set_tos... checking if linux/tcp.h has skb_tcp_all_headers... checking if linux/tcp.h has tcp_sock_set_syncnt... checking if linux/tcp.h has tcp_sock_set_nodelay... checking if blkdev_issue_flush has 2 params... yes
36.72 ./configure: line 93637: CONFDEFS_H_DIR/confdefs.h.563: No such file or directory
36.73 yes
36.73 ./configure: line 95765: CONFDEFS_H_DIR/confdefs.h.577: No such file or directory
36.74 yes
36.74 ./configure: line 94551: CONFDEFS_H_DIR/confdefs.h.569: No such file or directory
36.95 yes
36.95 ./configure: line 95923: CONFDEFS_H_DIR/confdefs.h.578: No such file or directory
37.25 yes
37.25 ./configure: line 95017: CONFDEFS_H_DIR/confdefs.h.572: No such file or directory
37.32 yes
37.32 ./configure: line 96687: CONFDEFS_H_DIR/confdefs.h.583: No such file or directory
37.34 no
37.34 no
37.34 yes
37.34 ./configure: line 95169: CONFDEFS_H_DIR/confdefs.h.573: No such file or directory
37.36 no
37.36 no
37.38 yes
37.38 ./configure: line 93941: CONFDEFS_H_DIR/confdefs.h.565: No such file or directory
37.38 no
37.41 no
37.42 yes
37.42 ./configure: line 94861: CONFDEFS_H_DIR/confdefs.h.571: No such file or directory
37.43 yes
37.43 ./configure: line 97139: CONFDEFS_H_DIR/confdefs.h.586: No such file or directory
37.43 yes
37.43 ./configure: line 96989: CONFDEFS_H_DIR/confdefs.h.585: No such file or directory
37.44 yes
37.44 ./configure: line 94247: CONFDEFS_H_DIR/confdefs.h.567: No such file or directory
37.45 yes
37.45 ./configure: line 97291: CONFDEFS_H_DIR/confdefs.h.587: No such file or directory
37.47 yes
37.47 ./configure: line 97443: CONFDEFS_H_DIR/confdefs.h.588: No such file or directory
37.48 yes
37.48 ./configure: line 97595: CONFDEFS_H_DIR/confdefs.h.589: No such file or directory
37.50 yes
37.50 ./configure: line 95317: CONFDEFS_H_DIR/confdefs.h.574: No such file or directory
37.56 yes
37.56 ./configure: line 93785: CONFDEFS_H_DIR/confdefs.h.564: No such file or directory
37.58 yes
37.58 ./configure: line 94093: CONFDEFS_H_DIR/confdefs.h.566: No such file or directory
37.60 yes
37.60 ./configure: line 93333: CONFDEFS_H_DIR/confdefs.h.561: No such file or directory
37.61 yes
37.61 ./configure: line 95465: CONFDEFS_H_DIR/confdefs.h.575: No such file or directory
37.64 yes
37.64 ./configure: line 98051: CONFDEFS_H_DIR/confdefs.h.592: No such file or directory
37.64 yes
37.64 ./configure: line 97899: CONFDEFS_H_DIR/confdefs.h.591: No such file or directory
37.64 yes
37.64 ./configure: line 96229: CONFDEFS_H_DIR/confdefs.h.580: No such file or directory
37.65 yes
37.65 ./configure: line 98203: CONFDEFS_H_DIR/confdefs.h.593: No such file or directory
37.66 yes
37.66 ./configure: line 95617: CONFDEFS_H_DIR/confdefs.h.576: No such file or directory
37.67 yes
37.67 ./configure: line 97747: CONFDEFS_H_DIR/confdefs.h.590: No such file or directory
37.73 yes
37.73 ./configure: line 93489: CONFDEFS_H_DIR/confdefs.h.562: No such file or directory
37.73 checking if net/sock.h has sock_no_linger... checking if net/sock.h has sock_set_priority... checking if net/sock.h has sock_set_reuseaddr... checking if linux/net.h has sendpage_ok... checking if ptp_find_pin_unlocked is defined... checking if uapi/linux/xfrm.h has XFRM_OFFLOAD_PACKET... checking if struct xfrm_offload has inner_ipproto... checking if genhd.h has bd_set_nr_sectors... checking if blkdev.h has QUEUE_FLAG_STABLE_WRITES... checking if genhd.h has revalidate_disk_size... checking if linux/blk-mq.h has blk_mq_set_request_complete... checking if linux/blkdev.h has blk_alloc_queue_rh... checking if blkdev.h struct request has block_device... checking if blkdev_issue_flush has 1 params... checking if bio.h has bio_max_segs... checking if trace_block_bio_remap has 4 param... checking if genhd.h has bd_set_size... checking if blk_execute_rq_nowait has 5 params... checking if blk_execute_rq_nowait has 3 params... checking if blk_execute_rq_nowait has 2 params... checking if blk_execute_rq has 4 params... checking if struct enum has member BIO_REMAPPED... checking if struct pci_driver has member sriov_get_vf_total_msix/sriov_set_msix_vec_count... checking if struct bio has member bi_bdev... checking if genhd.h has bdev_nr_sectors... checking if BLK_STS_ZONE_ACTIVE_RESOURCE is defined in blk_types... checking if dma-mapping.h has dma_set_min_align_mask... checking if bio.h has bio_for_each_bvec... checking if blk-mq.h has blk_mq_hctx_set_fq_lock_class... checking if bio.h has BIO_MAX_VECS... checking if blk-mq.h has blk_rq_bio_prep... checking if genhd.h has blk_alloc_disk with 1 param... checking if asm-generic/unaligned.h has put_unaligned_le24... yes
38.71 ./configure: line 99263: CONFDEFS_H_DIR/confdefs.h.600: No such file or directory
39.23 yes
39.23 ./configure: line 102467: CONFDEFS_H_DIR/confdefs.h.621: No such file or directory
39.26 yes
39.26 ./configure: line 101857: CONFDEFS_H_DIR/confdefs.h.617: No such file or directory
39.28 no
39.29 yes
39.29 ./configure: line 98961: CONFDEFS_H_DIR/confdefs.h.598: No such file or directory
39.29 no
39.32 yes
39.32 ./configure: line 101699: CONFDEFS_H_DIR/confdefs.h.616: No such file or directory
39.33 yes
39.33 ./configure: line 102315: CONFDEFS_H_DIR/confdefs.h.620: No such file or directory
39.33 no
39.33 no
39.33 yes
39.33 ./configure: line 102011: CONFDEFS_H_DIR/confdefs.h.618: No such file or directory
39.34 no
39.34 no
39.35 no
39.35 no
39.35 yes
39.35 ./configure: line 99723: CONFDEFS_H_DIR/confdefs.h.603: No such file or directory
39.36 yes
39.36 ./configure: line 100635: CONFDEFS_H_DIR/confdefs.h.609: No such file or directory
39.37 yes
39.37 ./configure: line 102163: CONFDEFS_H_DIR/confdefs.h.619: No such file or directory
39.37 yes
39.37 ./configure: line 102929: CONFDEFS_H_DIR/confdefs.h.624: No such file or directory
39.37 yes
39.37 ./configure: line 100483: CONFDEFS_H_DIR/confdefs.h.608: No such file or directory
39.37 yes
39.37 ./configure: line 99113: CONFDEFS_H_DIR/confdefs.h.599: No such file or directory
39.39 no
39.39 yes
39.39 ./configure: line 101395: CONFDEFS_H_DIR/confdefs.h.614: No such file or directory
39.39 yes
39.39 yes
39.39 ./configure: line 100027: CONFDEFS_H_DIR/confdefs.h.605: No such file or directory
39.39 ./configure: line 102627: CONFDEFS_H_DIR/confdefs.h.622: No such file or directory
39.40 yes
39.40 ./configure: line 103233: CONFDEFS_H_DIR/confdefs.h.626: No such file or directory
39.41 yes
39.41 ./configure: line 102777: CONFDEFS_H_DIR/confdefs.h.623: No such file or directory
39.42 yes
39.42 yes
39.42 ./configure: line 100333: CONFDEFS_H_DIR/confdefs.h.607: No such file or directory
39.42 ./configure: line 103081: CONFDEFS_H_DIR/confdefs.h.625: No such file or directory
39.49 yes
39.49 ./configure: line 98505: CONFDEFS_H_DIR/confdefs.h.595: No such file or directory
39.51 yes
39.51 ./configure: line 98657: CONFDEFS_H_DIR/confdefs.h.596: No such file or directory
39.52 yes
39.52 ./configure: line 98809: CONFDEFS_H_DIR/confdefs.h.597: No such file or directory
39.57 yes
39.57 ./configure: line 99419: CONFDEFS_H_DIR/confdefs.h.601: No such file or directory
39.57 checking if genhd.h has GENHD_FL_UP... checking if linux/blk-mq.h has blk_mq_alloc_disk 2 params... checking if struct blk_mq_ops has poll 2 args... checking if linux/blk-integrity.h exists... checking if struct bio has member bi_cookie... checking if genhd.h has device_add_disk retrun... checking if linux/fs.h has struct kiocb ki_complete 2 args... checking if blk_execute_rq has 2 params... checking if genhd.h has GENHD_FL_EXT_DEVT... checking if blk-mq.h struct request has rq_disk... checking if struct blk_mq_ops has queue_rqs... checking if bdev_nr_bytes exist... checking if pci_ids.h has PCI_VENDOR_ID_REDHAT... checking if acpi_storage_d3 exist... checking if linux/moduleparam.h has param_set_uint_minmax... checking if linux/blk-mq.h has blk_mq_wait_quiesce_done... checking if linux/blk-mq.h has blk_mq_wait_quiesce_done with tagset param... checking if timeout from struct blk_mq_ops has 1 param... checking if linux/blk-mq.h has blk_mq_destroy_queue... checking if blk_execute_rq has 3 params... checking if disk_uevent exist... checking if blk-cgroup.h has FC_APPID_LEN... checking if linux/bvec.h has bvec_virt... checking if net/sock.h has sock_setsockopt sockptr_t... checking if bio.h blk_next_bio has 3 parameters... checking if disk_update_readahead exists... checking if linux/vmalloc.h has __vmalloc 3 params... checking if bio.h bio_init has 5 parameters... checking if bio.h has bio_add_zone_append_page... checking if blkdev.h has blk_cleanup_disk()... checking if struct gendisk has conv_zones_bitmap... checking if blkdev.h has bdev_nr_zones... checking if blkdev.h has blk_queue_zone_sectors... yes
40.47 ./configure: line 105687: CONFDEFS_H_DIR/confdefs.h.642: No such file or directory
40.48 yes
40.48 ./configure: line 103385: CONFDEFS_H_DIR/confdefs.h.627: No such file or directory
40.48 yes
40.48 ./configure: line 105385: CONFDEFS_H_DIR/confdefs.h.640: No such file or directory
40.48 yes
40.48 ./configure: line 106771: CONFDEFS_H_DIR/confdefs.h.649: No such file or directory
40.62 no
40.93 yes
40.94 ./configure: line 105535: CONFDEFS_H_DIR/confdefs.h.641: No such file or directory
40.95 no
40.97 yes
40.97 ./configure: line 104473: CONFDEFS_H_DIR/confdefs.h.634: No such file or directory
41.04 no
41.08 no
41.10 no
41.10 no
41.11 yes
41.11 ./configure: line 107385: CONFDEFS_H_DIR/confdefs.h.653: No such file or directory
41.12 no
41.12 yes
41.12 ./configure: line 105839: CONFDEFS_H_DIR/confdefs.h.643: No such file or directory
41.12 yes
41.12 ./configure: line 104309: CONFDEFS_H_DIR/confdefs.h.633: No such file or directory
41.12 yes
41.13 ./configure: line 104625: CONFDEFS_H_DIR/confdefs.h.635: No such file or directory
41.13 yes
41.13 ./configure: line 105995: CONFDEFS_H_DIR/confdefs.h.644: No such file or directory
41.13 no
41.13 yes
41.13 ./configure: line 104157: CONFDEFS_H_DIR/confdefs.h.632: No such file or directory
41.14 yes
41.14 ./configure: line 107689: CONFDEFS_H_DIR/confdefs.h.655: No such file or directory
41.15 yes
41.15 ./configure: line 103855: CONFDEFS_H_DIR/confdefs.h.630: No such file or directory
41.15 yes
41.15 ./configure: line 106619: CONFDEFS_H_DIR/confdefs.h.648: No such file or directory
41.15 yes
41.15 ./configure: line 107841: CONFDEFS_H_DIR/confdefs.h.656: No such file or directory
41.16 yes
41.16 ./configure: line 105233: CONFDEFS_H_DIR/confdefs.h.639: No such file or directory
41.16 yes
41.16 ./configure: line 106925: CONFDEFS_H_DIR/confdefs.h.650: No such file or directory
41.16 yes
41.16 ./configure: line 104003: CONFDEFS_H_DIR/confdefs.h.631: No such file or directory
41.17 yes
41.17 ./configure: line 106163: CONFDEFS_H_DIR/confdefs.h.645: No such file or directory
41.18 yes
41.18 ./configure: line 108305: CONFDEFS_H_DIR/confdefs.h.659: No such file or directory
41.19 yes
41.19 ./configure: line 103689: CONFDEFS_H_DIR/confdefs.h.629: No such file or directory
41.19 yes
41.19 ./configure: line 105083: CONFDEFS_H_DIR/confdefs.h.638: No such file or directory
41.19 yes
41.19 ./configure: line 106315: CONFDEFS_H_DIR/confdefs.h.646: No such file or directory
41.27 yes
41.27 ./configure: line 107081: CONFDEFS_H_DIR/confdefs.h.651: No such file or directory
41.27 checking if uapi/linux/ptp_clock.h has PTP_PEROUT_DUTY_CYCLE... checking if net/dst_metadata.h has struct macsec_info... checking if net/macsec.c has function macsec_get_real_dev... checking if macsec_ops has boolean field rx_uses_md_dst... checking if flow_dissector.h has FLOW_DISSECTOR_F_STOP_BEFORE_ENCAP... checking if Linux was built with symbol rpc_task_gfp_mask exported... yes
41.28 checking if net/macsec.c has function macsec_netdev_is_offloaded... checking if net/macsec.h has function macsec_netdev_priv... checking if struct macsec_context has update_pn... checking if linux/fs.h struct file_operations has uring_cmd... checking if linux/blkdev.h has function disk_set_zoned... checking if uapi/linux/nvme_ioctl.h has NVME_IOCTL_IO64_CMD_VEC... checking if linux/t10-pi.h has ext_pi_ref_tag... checking if linux/blk_types.h has blk_opf_t... checking if linux/fs.h sruct file has f_iocb_flags... checking if blkdev.h has bdev_max_zone_append_sectors... checking if file linux/blk-mq.h has enum rq_end_io_ret... checking if function map_queues returns int... checking if linux/blk-cgroup has blkcg_get_fc_appid... checking if linux/blkdev.h has blkdev_compat_ptr_ioctl... checking if net/vxlan.h has VXLAN_GBP_MASK... checking if struct tc_skb_ext has act_miss... checking if net/vxlan.h has vxlan_build_gbp_hdr... checking if struct flow_action_entry has hw_index... checking if struct flow_action_entry has miss_cookie... checking if struct flow_action_entry has cookie... checking if flow_cls_offload has use_act_stats... checking if uapi/linux/nvme_ioctl.h has NVME_URING_CMD_ADMIN... checking if linux/blk-mq.h has blk_mq_quiesce_tagset... checking if linux/blk-mq.h has blk_rq_map_user_io... checking if linux/blkdev.h has bdev_start_io_acct... checking if linux/blkdev.h has bdev_start_io_acct... checking if linux/fs.h struct file_operations has uring_cmd_iopoll... checking if linux/pr.h has enum pr_status... yes
42.16 ./configure: line 108609: CONFDEFS_H_DIR/confdefs.h.661: No such file or directory
42.19 yes
42.19 yes
42.19 ./configure: line 110173: CONFDEFS_H_DIR/confdefs.h.671: No such file or directory
42.19 ./configure: line 112631: CONFDEFS_H_DIR/confdefs.h.687: No such file or directory
42.19 yes
42.19 ./configure: line 111245: CONFDEFS_H_DIR/confdefs.h.678: No such file or directory
42.21 yes
42.21 ./configure: line 109219: CONFDEFS_H_DIR/confdefs.h.665: No such file or directory
42.69 yes
42.69 ./configure: line 110631: CONFDEFS_H_DIR/confdefs.h.674: No such file or directory
42.70 yes
42.70 ./configure: line 109867: CONFDEFS_H_DIR/confdefs.h.669: No such file or directory
42.70 yes
42.70 ./configure: line 113387: CONFDEFS_H_DIR/confdefs.h.692: No such file or directory
42.77 yes
42.77 ./configure: line 110931: CONFDEFS_H_DIR/confdefs.h.676: No such file or directory
42.77 yes
42.77 ./configure: line 110019: CONFDEFS_H_DIR/confdefs.h.670: No such file or directory
42.77 no
42.78 yes
42.78 ./configure: line 110475: CONFDEFS_H_DIR/confdefs.h.673: No such file or directory
42.79 no
42.79 no
42.81 yes
42.81 ./configure: line 112781: CONFDEFS_H_DIR/confdefs.h.688: No such file or directory
42.82 no
42.85 yes
42.85 ./configure: line 111395: CONFDEFS_H_DIR/confdefs.h.679: No such file or directory
42.86 yes
42.86 ./configure: line 113231: CONFDEFS_H_DIR/confdefs.h.691: No such file or directory
42.88 yes
42.88 ./configure: line 110781: CONFDEFS_H_DIR/confdefs.h.675: No such file or directory
42.88 yes
42.88 ./configure: line 112325: CONFDEFS_H_DIR/confdefs.h.685: No such file or directory
42.88 yes
42.88 ./configure: line 112479: CONFDEFS_H_DIR/confdefs.h.686: No such file or directory
42.90 yes
42.90 ./configure: line 112931: CONFDEFS_H_DIR/confdefs.h.689: No such file or directory
42.90 yes
42.90 ./configure: line 112157: CONFDEFS_H_DIR/confdefs.h.684: No such file or directory
42.92 yes
42.92 ./configure: line 112003: CONFDEFS_H_DIR/confdefs.h.683: No such file or directory
42.92 yes
42.92 ./configure: line 109557: CONFDEFS_H_DIR/confdefs.h.667: No such file or directory
42.92 yes
42.92 ./configure: line 110323: CONFDEFS_H_DIR/confdefs.h.672: No such file or directory
42.93 yes
42.93 ./configure: line 108913: CONFDEFS_H_DIR/confdefs.h.663: No such file or directory
42.99 yes
42.99 ./configure: line 109405: CONFDEFS_H_DIR/confdefs.h.666: No such file or directory
42.99 yes
42.99 ./configure: line 109067: CONFDEFS_H_DIR/confdefs.h.664: No such file or directory
42.99 yes
42.99 ./configure: line 109711: CONFDEFS_H_DIR/confdefs.h.668: No such file or directory
43.05 yes
43.05 ./configure: line 108761: CONFDEFS_H_DIR/confdefs.h.662: No such file or directory
43.09 yes
43.09 yes
43.09 ./configure: line 111849: CONFDEFS_H_DIR/confdefs.h.682: No such file or directory
43.09 ./configure: line 111545: CONFDEFS_H_DIR/confdefs.h.680: No such file or directory
43.10 checking if linux/bvec.h has bvec_set_virt... checking if linux/dma-mapping.h has dma_opt_mapping_size... checking if linux/blk-mq.h has blk_mq_rq_state... checking if linux/uio.h has ITER_DEST... checking if linux/bvec.h has bvec_set_page... checking if linux/blkdev.h has bdev_discard_granularity... checking if kstrtox.h exist... checking if linux/blkdev.h has bdev_write_cache... checking if trace/events/sock.h has trace_sk_data_ready... checking if linux/atomic/atomic-instrumented.h has try_cmpxchg... checking if linux/blkdev.h has bdev_zone_no... checking if linux/blkdev.h has bdev_start_io_acct... checking if linux/blkdev.h has bdev_is_partition... checking if struct gendisk has open_mode... checking if BLK_STS_RESV_CONFLICT is defined in blk_types... checking if linux/blkdev.h has blkdev_put with holder param... checking if struct proto_ops has sendpage... checking if linux/blk-mq.h blk_mq_tag_set has member nr_maps... checking if blk-mq.h has enum hctx_type... checking if struct irq_affinity has priv... checking if linux/aer.h has pci_enable_pcie_error_reporting... checking if linux/blk-mq.h blk_mq_tag_set has member map... checking if blkdev.h has QUEUE_FLAG_PCI_P2PDMA... checking if blkdev.h struct request has deadline... checking if struct blk_mq_ops has commit_rqs... checking if linux/overflow.h has struct_size_t... checking if linux/pr.h has struct pr_keys... checking if linux/dma-mapping.h has dma_max_mapping_size... checking if scsi/scsi_transport_fc.h has FC_PORT_ROLE_NVME_TARGET... checking if linux/io_uring/cmd.h exists... checking if hwmon_chip_info get const nvme_hwmon_ops... checking if nvme_auth_transform_key returns struct nvme_dhchap_key *... checking if bio.h has bio_integrity_map_user... no
43.94 no
43.96 yes
43.96 ./configure: line 118249: CONFDEFS_H_DIR/confdefs.h.724: No such file or directory
43.98 yes
43.98 ./configure: line 114585: CONFDEFS_H_DIR/confdefs.h.700: No such file or directory
43.98 yes
43.98 ./configure: line 117487: CONFDEFS_H_DIR/confdefs.h.719: No such file or directory
44.19 yes
44.19 ./configure: line 116563: CONFDEFS_H_DIR/confdefs.h.713: No such file or directory
44.22 yes
44.22 ./configure: line 115039: CONFDEFS_H_DIR/confdefs.h.703: No such file or directory
44.24 yes
44.24 ./configure: line 114137: CONFDEFS_H_DIR/confdefs.h.697: No such file or directory
44.27 no
44.37 yes
44.37 ./configure: line 113539: CONFDEFS_H_DIR/confdefs.h.693: No such file or directory
44.42 no
44.46 yes
44.46 ./configure: line 117641: CONFDEFS_H_DIR/confdefs.h.720: No such file or directory
44.49 yes
44.49 ./configure: line 117791: CONFDEFS_H_DIR/confdefs.h.721: No such file or directory
44.53 yes
44.53 ./configure: line 113839: CONFDEFS_H_DIR/confdefs.h.695: No such file or directory
44.56 yes
44.56 ./configure: line 115797: CONFDEFS_H_DIR/confdefs.h.708: No such file or directory
44.56 yes
44.56 ./configure: line 114287: CONFDEFS_H_DIR/confdefs.h.698: No such file or directory
44.56 yes
44.56 ./configure: line 116407: CONFDEFS_H_DIR/confdefs.h.712: No such file or directory
44.56 yes
44.56 ./configure: line 113689: CONFDEFS_H_DIR/confdefs.h.694: No such file or directory
44.57 yes
44.57 ./configure: line 114437: CONFDEFS_H_DIR/confdefs.h.699: No such file or directory
44.58 yes
44.58 ./configure: line 117173: CONFDEFS_H_DIR/confdefs.h.717: No such file or directory
44.58 no
44.59 yes
44.59 ./configure: line 115189: CONFDEFS_H_DIR/confdefs.h.704: No such file or directory
44.59 yes
44.59 ./configure: line 116869: CONFDEFS_H_DIR/confdefs.h.715: No such file or directory
44.60 yes
44.60 ./configure: line 115489: CONFDEFS_H_DIR/confdefs.h.706: No such file or directory
44.61 yes
44.61 ./configure: line 114735: CONFDEFS_H_DIR/confdefs.h.701: No such file or directory
44.61 yes
44.61 ./configure: line 116255: CONFDEFS_H_DIR/confdefs.h.711: No such file or directory
44.61 yes
44.61 ./configure: line 117021: CONFDEFS_H_DIR/confdefs.h.716: No such file or directory
44.61 yes
44.61 ./configure: line 115645: CONFDEFS_H_DIR/confdefs.h.707: No such file or directory
44.63 yes
44.63 ./configure: line 113989: CONFDEFS_H_DIR/confdefs.h.696: No such file or directory
44.64 yes
44.64 yes
44.64 ./configure: line 117329: CONFDEFS_H_DIR/confdefs.h.718: No such file or directory
44.64 ./configure: line 115947: CONFDEFS_H_DIR/confdefs.h.709: No such file or directory
44.65 yes
44.65 ./configure: line 117943: CONFDEFS_H_DIR/confdefs.h.722: No such file or directory
44.79 yes
44.79 ./configure: line 114885: CONFDEFS_H_DIR/confdefs.h.702: No such file or directory
44.79 checking if pci.h has pcie_capability_clear_and_set_word_locked... checking if linux/blk_types.h has PAGE_SECTORS_SHIFT... checking if linux/blkdev.h has bdev_release... checking if linux/compat.h has in_compat_syscall... checking if linux/compat.h has compat_uptr_t... checking if blk_alloc_queue_node has 3 args... checking if blkdev.h struct request has mq_hctx... checking if linux/blk-mq.h has struct blk_mq_queue_map... checking if linux/blk-mq.h has struct blk_holder_ops... checking if struct sock has sk_use_task_frag... checking if genhd.h has blk_alloc_disk with 2 params... checking if blkdev.h has queue_limits_commit_update... checking if struct blk_integrity has pi_offset... checking if linux/blk-mq.h has blk_mq_alloc_disk 3 params... checking if linux/blk-mq.h has blk_mq_alloc_queue... checking if linux/blkdev.h has bdev_file_open_by_path... checking if linux/gfp.h has page_frag_cache_drain... checking if linux/blkdev.h has blkdev_zone_mgmt with 5 params... checking if linux/ratelimit_types.h exists... checking if linux/blkdev.h has blk_op_str... checking if linux/blkdev.h struct request_queue has member disk... checking if blkdev.h has QUEUE_FLAG_DISCARD... checking if struct devlink_port_ops has max_io_eqs... checking if blk-mq.h or blkdev.h has RQF_MQ_INFLIGHT... yes
45.53 ./configure: line 121431: CONFDEFS_H_DIR/confdefs.h.745: No such file or directory
45.80 no
45.89 yes
45.89 ./configure: line 119311: CONFDEFS_H_DIR/confdefs.h.731: No such file or directory
45.96 yes
45.96 ./configure: line 119159: CONFDEFS_H_DIR/confdefs.h.730: No such file or directory
45.99 no
45.99 no
46.03 yes
46.03 ./configure: line 119767: CONFDEFS_H_DIR/confdefs.h.734: No such file or directory
46.03 no
46.05 no
46.05 yes
46.05 ./configure: line 119007: CONFDEFS_H_DIR/confdefs.h.729: No such file or directory
46.05 no
46.06 no
46.06 yes
46.06 ./configure: line 118855: CONFDEFS_H_DIR/confdefs.h.728: No such file or directory
46.07 no
46.07 no
46.08 yes
46.08 ./configure: line 118703: CONFDEFS_H_DIR/confdefs.h.727: No such file or directory
46.09 yes
46.09 ./configure: line 119615: CONFDEFS_H_DIR/confdefs.h.733: No such file or directory
46.09 no
46.10 no
46.11 no
46.13 yes
46.13 ./configure: line 121583: CONFDEFS_H_DIR/confdefs.h.746: No such file or directory
46.13 yes
46.13 ./configure: line 122199: CONFDEFS_H_DIR/confdefs.h.750: No such file or directory
46.13 yes
46.13 ./configure: line 119919: CONFDEFS_H_DIR/confdefs.h.735: No such file or directory
46.14 yes
46.14 ./configure: line 121735: CONFDEFS_H_DIR/confdefs.h.747: No such file or directory
46.26 yes
46.26 ./configure: line 120069: CONFDEFS_H_DIR/confdefs.h.736: No such file or directory
46.26 ./configure: line 122228: /bin/cat: No such file or directory
46.27 checking that generated files are newer than configure... done
46.27 configure: creating ./config.status
46.31 config.status: creating Makefile
46.32 config.status: creating config.h
46.32 config.status: executing depfiles commands
46.32
46.32 CC:            gcc
46.32 LD:            ld
46.32 CFLAGS:        -g0 -Os
46.32 EXTRA_KCFLAGS: -include /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/compat/config.h
46.32
46.32 Type 'make' to build kernel modules.
46.34 /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1
46.82 egrep: warning: egrep is obsolescent; using grep -E
47.06 Building kernel modules
47.06 Kernel version: 6.10.7-arch1-1
47.06 Modules directory: /lib/modules/6.10.7-arch1-1/extra/mlnx-ofa_kernel
47.06 Kernel build: /src
47.06 Kernel sources: /src
47.06 env CWD=/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1 BACKPORT_INCLUDES= \
47.06 	make -C /src M="/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1" \
47.06 	V=0 KBUILD_NOCMDDEP=1  \
47.06 	CONFIG_COMPAT_VERSION= \
47.06 	CONFIG_COMPAT_KOBJECT_BACKPORT= \
47.06 	CONFIG_MEMTRACK= \
47.06 	CONFIG_DEBUG_INFO=y \
47.06 	CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT=y \
47.06 	CONFIG_INFINIBAND=m \
47.06 	CONFIG_INFINIBAND_CORE_DUMMY= \
47.06 	CONFIG_INFINIBAND_IPOIB=m \
47.06 	CONFIG_IPOIB_VERSION= \
47.06 	CONFIG_INFINIBAND_IPOIB_CM=y \
47.06 	CONFIG_IPOIB_ALL_MULTI= \
47.06                 CONFIG_INFINIBAND_MLNX_BX= \
47.06 	CONFIG_INFINIBAND_SRP=m \
47.06 	CONFIG_INFINIBAND_SRP_DUMMY= \
47.06 	CONFIG_MLX5_VDPA_NET_DUMMY= \
47.06 	CONFIG_RDMA_RXE= \
47.06 	CONFIG_RDMA_RXE_DUMMY= \
47.06 	CONFIG_NVME_CORE= \
47.06 	CONFIG_NVME_HOST_WITHOUT_FC= \
47.06 	CONFIG_BLK_DEV_NVME= \
47.06 	CONFIG_NVME_FABRICS= \
47.06 	CONFIG_NVME_FC= \
47.06 	CONFIG_NVME_RDMA= \
47.06 	CONFIG_NVME_TCP= \
47.06 	CONFIG_NVME_APPLE= \
47.06 	CONFIG_NVME_HOST_AUTH= \
47.06 	CONFIG_NVME_MULTIPATH= \
47.06 	CONFIG_NVME_HOST_DUMMY= \
47.06 	CONFIG_NVME_TARGET= \
47.06 	CONFIG_NVME_TARGET_LOOP= \
47.06 	CONFIG_NVME_TARGET_RDMA= \
47.06 	CONFIG_NVME_TARGET_TCP= \
47.06 	CONFIG_NVME_TARGET_FC= \
47.06 	CONFIG_NVME_TARGET_FCLOOP= \
47.06 	CONFIG_NVME_TARGET_DUMMY= \
47.06 	CONFIG_NVME_COMMON= \
47.06 	CONFIG_SCSI_SRP_ATTRS=m \
47.06 	CONFIG_INFINIBAND_USER_MAD=m \
47.06 	CONFIG_INFINIBAND_USER_ACCESS=m \
47.06 	CONFIG_INFINIBAND_USER_ACCESS_UCM=m \
47.06 	CONFIG_INFINIBAND_USER_MEM=y \
47.06 	CONFIG_INFINIBAND_ADDR_TRANS=y \
47.06 	CONFIG_INFINIBAND_ADDR_TRANS_CONFIGFS=y \
47.06 	CONFIG_INFINIBAND_IPOIB_DEBUG=y \
47.06 	CONFIG_INFINIBAND_ISERT= \
47.06 	CONFIG_INFINIBAND_ISERT_DUMMY= \
47.06 	CONFIG_INFINIBAND_ISER=m \
47.06 	CONFIG_INFINIBAND_ISER_DUMMY= \
47.06 	CONFIG_SCSI_ISCSI_ATTRS=m \
47.06 	CONFIG_ISCSI_TCP= \
47.06 	CONFIG_INFINIBAND_IPOIB_DEBUG_DATA= \
47.06 	CONFIG_INFINIBAND_SDP_SEND_ZCOPY= \
47.06 	CONFIG_INFINIBAND_SDP_RECV_ZCOPY= \
47.06 	CONFIG_INFINIBAND_SDP_DEBUG= \
47.06 	CONFIG_INFINIBAND_SDP_DEBUG_DATA= \
47.06 	CONFIG_INFINIBAND_MADEYE= \
47.06 	CONFIG_MLXFW= \
47.06 	CONFIG_MLX5_CORE=m \
47.06 	CONFIG_MLX5_ACCEL=y \
47.06 	CONFIG_MLX5_EN_TLS= \
47.06 	CONFIG_MLX5_TLS= \
47.06 	CONFIG_MLX5_FPGA_TLS= \
47.06 	CONFIG_MLX5_FPGA_IPSEC= \
47.06 	CONFIG_MLX5_IPSEC= \
47.06 	CONFIG_MLX5_EN_IPSEC= \
47.06 	CONFIG_MLX5_FPGA= \
47.06 	CONFIG_MLX5_CORE_EN=y \
47.06 	CONFIG_MLX5_CORE_EN_DCB=y \
47.06 	CONFIG_MLX5_EN_ARFS=y \
47.06 	CONFIG_MLX5_EN_RXNFC=y \
47.06 	CONFIG_MLX5_MPFS=y \
47.06 	CONFIG_MLX5_ESWITCH=y \
47.06 	CONFIG_MLX5_CLS_ACT=y \
47.06 	CONFIG_MLX5_BRIDGE=y \
47.06 	CONFIG_MLX5_TC_CT=n \
47.06 	CONFIG_MLX5_SF=y \
47.06 	CONFIG_MLX5_SF_MANAGER=y \
47.06 	CONFIG_MLX5_SW_STEERING=y \
47.06 	CONFIG_MLX5_CORE_IPOIB=y \
47.06 	CONFIG_MLX5_INFINIBAND=m \
47.06 	CONFIG_MLX5_DEBUG=y \
47.06 	CONFIG_AUXILIARY_BUS= \
47.06 	CONFIG_FWCTL=m \
47.06 	CONFIG_FWCTL_MLX5=m \
47.06 	CONFIG_SUNRPC_XPRT_RDMA= \
47.06 	CONFIG_SUNRPC_XPRT_RDMA_DUMMY= \
47.06 	CONFIG_DTRACE= \
47.06 	CONFIG_CTF= \
47.06 	CONFIG_INFINIBAND_ON_DEMAND_PAGING=y \
47.06 	CONFIG_BF_DEVICE_EMULATION= \
47.06 	CONFIG_BF_POWER_FAILURE_EVENT= \
47.06 	CONFIG_GPU_DIRECT_STORAGE= \
47.06 	CONFIG_ENABLE_MLX5_FS_DEBUGFS= \
47.06 	CONFIG_MLXDEVM=m \
47.06 	CONFIG_MLX5_SF_CFG= \
47.06 	CONFIG_MLX5_TC_SAMPLE=y \
47.06 	CONFIG_MLX5_MACSEC= \
47.06 	CONFIG_MLX5_DPLL= \
47.06 	CONFIG_MLNX_EN= \
47.06 	CONFIG_GCC_VERSION=130300 \
47.06 	CONFIG_IS_MARINER= \
47.06 	LINUXINCLUDE='-D__OFED_BUILD__ -D__KERNEL__ -g0 -Os -DCOMPAT_BASE="\"mlnx-ofa_kernel-compat-20240811-1029-51d9270\"" -DCOMPAT_BASE_TREE="\"https://${SVC_OFED_BOT_USER}:${SVC_OFED_BOT_KEY}@git-nbu.nvidia.com/r/a/mlnx_ofed/mlnx-ofa_kernel-4.0.git\"" -DCOMPAT_BASE_TREE_VERSION="\"51d9270\"" -DCOMPAT_PROJECT="\"Compat-mlnx-ofed\"" -DCOMPAT_VERSION="\"51d9270\""  -include   -include /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/include/linux/compat-2.6.h    -I/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/include -I/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/include/uapi -I/tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/debug $(if $(CONFIG_XEN),-D__XEN_INTERFACE_VERSION__=$(CONFIG_XEN_INTERFACE_VERSION)) $(if $(CONFIG_XEN),-I$(srctree)/arch/x86/include/mach-xen) -I$(srctree)/arch/$(SRCARCH)/include -Iarch/$(SRCARCH)/include/generated -Iinclude -I$(srctree)/arch/$(SRCARCH)/include/uapi -Iarch/$(SRCARCH)/include/generated/uapi -I$(srctree)/include -I$(srctree)/include/uapi -Iinclude/generated/uapi $(if $(KBUILD_SRC),-Iinclude2 -I$(srctree)/include) -I$(srctree)/arch/$(SRCARCH)/include -Iarch/$(SRCARCH)/include/generated ' \
47.06 	modules
47.06 make[1]: Entering directory '/src'
47.64   CC [M]  /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/compat/main.o
47.64   CC [M]  /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/compat/output_core.o
47.64 gcc: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files
47.64 compilation terminated.
47.64   CC [M]  /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/scsi/scsi_transport_srp.o
47.64 make[4]: *** [scripts/Makefile.build:243: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/compat/main.o] Error 1
47.64 make[4]: *** Waiting for unfinished jobs....
47.64   CC [M]  /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/net/mlxdevm/mlxdevm.o
47.64   CC [M]  /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/net/ethernet/mellanox/mlxsw/spectrum_main.o
47.64 gcc: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files
47.64 compilation terminated.
47.64 make[4]: *** [scripts/Makefile.build:243: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/compat/output_core.o] Error 1
47.64   CC [M]  /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/compat/interval_tree.o
47.64 gcc: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files
47.64 compilation terminated.
47.64 make[4]: *** [scripts/Makefile.build:243: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/scsi/scsi_transport_srp.o] Error 1
47.64 gcc: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files
47.64 make[3]: *** [scripts/Makefile.build:480: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/scsi] Error 2
47.64 compilation terminated.
47.64 make[3]: *** Waiting for unfinished jobs....
47.64 gcc: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files
47.64 compilation terminated.
47.64 make[4]: *** [scripts/Makefile.build:243: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/net/mlxdevm/mlxdevm.o] Error 1
47.64 make[4]: *** [scripts/Makefile.build:243: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/net/ethernet/mellanox/mlxsw/spectrum_main.o] Error 1
47.64 make[3]: *** [scripts/Makefile.build:480: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/net/mlxdevm] Error 2
47.64 make[3]: *** [scripts/Makefile.build:480: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/net/ethernet/mellanox/mlxsw] Error 2
47.64 gcc: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files
47.64 compilation terminated.
47.64 make[4]: *** [scripts/Makefile.build:243: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/compat/interval_tree.o] Error 1
47.64 make[3]: *** [scripts/Makefile.build:480: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/compat] Error 2
47.65   CC [M]  /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/net/ethernet/mellanox/mlx5/core/main.o
47.65   CC [M]  /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/core/packer.o
47.65 gcc: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files
47.65 compilation terminated.
47.65   CC [M]  /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/net/ethernet/mellanox/mlx5/core/cmd.o
47.65 gcc: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files
47.65 compilation terminated.
47.65 make[4]: *** [scripts/Makefile.build:243: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/net/ethernet/mellanox/mlx5/core/main.o] Error 1
47.65 make[4]: *** Waiting for unfinished jobs....
47.65   CC [M]  /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/ulp/ipoib/ipoib_main.o
47.65   CC [M]  /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/ulp/srp/ib_srp.o
47.65   CC [M]  /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/hw/efa/efa_main.o
47.65   CC [M]  /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/core/ud_header.o
47.65   CC [M]  /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/hw/mlx4/main.o
47.65 make[5]: *** [scripts/Makefile.build:243: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/core/packer.o] Error 1
47.65 make[5]: *** Waiting for unfinished jobs....
47.65 gcc: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files
47.65 compilation terminated.
47.65 make[4]: *** [scripts/Makefile.build:243: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/net/ethernet/mellanox/mlx5/core/cmd.o] Error 1
47.65 make[3]: *** [scripts/Makefile.build:480: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/net/ethernet/mellanox/mlx5/core] Error 2
47.65   CC [M]  /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/hw/mlx5/ah.o
47.65   CC [M]  /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/ulp/iser/ib_iser_dummy.o
47.65 gcc: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files
47.65 compilation terminated.
47.65   CC [M]  /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/ulp/ipoib/ipoib_ib.o
47.65 gcc: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files
47.65 compilation terminated.
47.65 gcc: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files
47.65 compilation terminated.
47.65 gcc: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files
47.65 compilation terminated.
47.65 gcc: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files
47.65 compilation terminated.
47.65 make[6]: *** [scripts/Makefile.build:243: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/ulp/srp/ib_srp.o] Error 1
47.65 make[6]: *** [scripts/Makefile.build:243: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/hw/efa/efa_main.o] Error 1
47.65 make[5]: *** [scripts/Makefile.build:480: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/ulp/srp] Error 2
47.65 make[6]: *** [scripts/Makefile.build:243: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/hw/mlx4/main.o] Error 1
47.65 make[5]: *** [scripts/Makefile.build:243: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/core/ud_header.o] Error 1
47.65 make[5]: *** Waiting for unfinished jobs....
47.65 make[5]: *** [scripts/Makefile.build:480: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/hw/efa] Error 2
47.65 make[5]: *** Waiting for unfinished jobs....
47.65 make[5]: *** [scripts/Makefile.build:480: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/hw/mlx4] Error 2
47.65 make[4]: *** [scripts/Makefile.build:480: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/core] Error 2
47.65 make[4]: *** Waiting for unfinished jobs....
47.65 make[6]: *** [scripts/Makefile.build:243: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/ulp/ipoib/ipoib_main.o] Error 1
47.65 make[6]: *** Waiting for unfinished jobs....
47.65 gcc: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files
47.65 compilation terminated.
47.65   CC [M]  /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/hw/mlx5/cmd.o
47.65 gcc: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files
47.65 compilation terminated.
47.65 make[6]: *** [scripts/Makefile.build:243: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/ulp/iser/ib_iser_dummy.o] Error 1
47.65 gcc: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files
47.65 compilation terminated.
47.65 make[5]: *** [scripts/Makefile.build:480: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/ulp/iser] Error 2
47.65   CC [M]  /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/ulp/ipoib/ipoib_multicast.o
47.65 make[6]: *** [scripts/Makefile.build:243: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/hw/mlx5/ah.o] Error 1
47.65 make[6]: *** Waiting for unfinished jobs....
47.65 make[6]: *** [scripts/Makefile.build:243: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/ulp/ipoib/ipoib_ib.o] Error 1
47.65 gcc: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files
47.65 compilation terminated.
47.65   CC [M]  /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/hw/mlx5/cong.o
47.65 make[6]: *** [scripts/Makefile.build:243: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/hw/mlx5/cmd.o] Error 1
47.65 gcc: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files
47.65 compilation terminated.
47.65 make[6]: *** [scripts/Makefile.build:243: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/ulp/ipoib/ipoib_multicast.o] Error 1
47.65 make[5]: *** [scripts/Makefile.build:480: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/ulp/ipoib] Error 2
47.65 make[4]: *** [scripts/Makefile.build:480: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/ulp] Error 2
47.65 gcc: fatal error: cannot specify '-o' with '-c', '-S' or '-E' with multiple files
47.65 compilation terminated.
47.65 make[6]: *** [scripts/Makefile.build:243: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/hw/mlx5/cong.o] Error 1
47.65 make[5]: *** [scripts/Makefile.build:480: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/hw/mlx5] Error 2
47.65 make[4]: *** [scripts/Makefile.build:480: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband/hw] Error 2
47.65 make[3]: *** [scripts/Makefile.build:480: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1/drivers/infiniband] Error 2
47.65 make[2]: *** [/src/Makefile:1921: /tmp/build/0/SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1] Error 2
47.65 make[1]: *** [Makefile:234: __sub-make] Error 2
47.65 make[1]: Leaving directory '/src'
47.65 make: *** [makefile:165: kernel] Error 2
------
ERROR: failed to solve: process "/toolchain/bin/bash -c set -eou pipefail\ncd SOURCES/mlnx-ofed-kernel-24.07.OFED.24.07.0.6.1.1\n\n./configure --with-core-mod \\\n  --with-user_mad-mod \\\n  --with-user_access-mod \\\n  --with-addr_trans-mod \\\n  --with-mlx5-mod \\\n  --with-ipoib-mod \\\n  --with-srp-mod \\\n  --with-iser-mod \\\n  --kernel-sources=/src \\\n  -j $(nproc)\n\nmake kernel -j $(nproc)\n" did not complete successfully: exit code: 2
make[2]: *** [Makefile:149: target-mellanox-ofed-pkg] Error 1
make[2]: Leaving directory '/home/jpg/src/talos/pkgs'
make[1]: *** [Makefile:155: docker-mellanox-ofed-pkg] Error 2
make[1]: Leaving directory '/home/jpg/src/talos/pkgs'
make: *** [Makefile:172: mellanox-ofed-pkg] Error 2
```